### PR TITLE
Replace sign-in clickable help text by a secondary button

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
@@ -18,8 +18,6 @@ package com.jeanbarrossilva.orca.core.mastodon.auth.authorization
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -52,13 +50,14 @@ import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
 import com.jeanbarrossilva.orca.core.mastodon.R
 import com.jeanbarrossilva.orca.core.mastodon.auth.authorization.viewmodel.MastodonAuthorizationViewModel
-import com.jeanbarrossilva.orca.platform.autos.colors.asColor
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.PrimaryButton
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.SecondaryButton
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.containsErrorsAsState
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.rememberErrorDispatcher
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.Scaffold
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.button.ButtonBar
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.button.ButtonBarDefaults
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBar
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.plus
@@ -71,8 +70,7 @@ import com.jeanbarrossilva.orca.platform.ui.core.requestFocusWithDelay
  *
  * @param viewModel [MastodonAuthorizationViewModel] to which updates to the inserted [Domain] will
  *   be sent.
- * @param onHelp Action to be performed when the concept of an instance is requested to be
- *   explained.
+ * @param onHelp Action to be performed when help is requested.
  * @param modifier [Modifier] to be applied to the underlying [Box].
  */
 @Composable
@@ -98,8 +96,7 @@ internal fun MastodonAuthorization(
  * @param domain [String] version of the [Domain].
  * @param onDomainChange Callback run whenever the user inputs to the domain [TextField].
  * @param onSignIn Callback run whenever the sign-in [PrimaryButton] is clicked.
- * @param onHelp Action to be performed when the concept of an instance is requested to be
- *   explained.
+ * @param onHelp Action to be performed when help is requested.
  * @param modifier [Modifier] to be applied to the underlying [Box].
  */
 @Composable
@@ -140,38 +137,28 @@ internal fun MastodonAuthorization(
   Box(modifier) {
     Scaffold(
       buttonBar = {
-        Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
-          Column(
-            Modifier.padding(start = spacing, end = spacing),
-            Arrangement.spacedBy(AutosTheme.spacings.medium.dp)
+        Column(verticalArrangement = Arrangement.spacedBy(ButtonBarDefaults.spacing)) {
+          TextField(
+            domain,
+            onDomainChange,
+            Modifier.focusRequester(focusRequester)
+              .padding(start = ButtonBarDefaults.spacing, end = ButtonBarDefaults.spacing)
+              .fillMaxWidth(),
+            errorDispatcher,
+            KeyboardOptions(imeAction = ImeAction.Go),
+            KeyboardActions(onGo = { onDone() }),
+            isSingleLined = true
           ) {
-            TextField(
-              domain,
-              onDomainChange,
-              Modifier.focusRequester(focusRequester).fillMaxWidth(),
-              errorDispatcher,
-              KeyboardOptions(imeAction = ImeAction.Go),
-              KeyboardActions(onGo = { onDone() }),
-              isSingleLined = true
-            ) {
-              Text(stringResource(R.string.core_http_authorization_domain))
-            }
-
-            Text(
-              stringResource(R.string.core_http_authorization_help),
-              Modifier.clickable(
-                remember(::MutableInteractionSource),
-                indication = null,
-                onClick = onHelp
-              ),
-              color = AutosTheme.colors.link.asColor,
-              style = AutosTheme.typography.labelMedium
-            )
+            Text(stringResource(R.string.core_http_authorization_domain))
           }
 
           ButtonBar(lazyListState) {
             PrimaryButton(onClick = onDone, isEnabled = !containsErrors) {
               Text(stringResource(R.string.core_http_authorization_sign_in))
+            }
+
+            SecondaryButton(onClick = onHelp) {
+              Text(stringResource(R.string.core_http_authorization_help))
             }
           }
         }

--- a/core/mastodon/src/main/res/values-pt-rBR/strings.xml
+++ b/core/mastodon/src/main/res/values-pt-rBR/strings.xml
@@ -19,7 +19,7 @@
     <string name="core_http_authorization_account_origin">De onde é a sua conta?</string>
     <string name="core_http_authorization_domain">Instância</string>
     <string name="core_http_authorization_empty_domain">A instância não pode estar vazia.</string>
-    <string name="core_http_authorization_help">O que é uma instância?</string>
+    <string name="core_http_authorization_help">Eu não tenho uma conta</string>
     <string name="core_http_authorization_invalid_domain">
         Infelizmente, essa não é uma instância válida.
     </string>

--- a/core/mastodon/src/main/res/values/strings.xml
+++ b/core/mastodon/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="core_http_authorization_account_origin">Where is your account from?</string>
     <string name="core_http_authorization_domain">Instance</string>
     <string name="core_http_authorization_empty_domain">Instance cannot be empty.</string>
-    <string name="core_http_authorization_help">What is an instance?</string>
+    <string name="core_http_authorization_help">I don\'t have an account</string>
     <string name="core_http_authorization_invalid_domain">
         Unfortunately, this isn\'t a valid instance.
     </string>

--- a/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/ButtonScopeTests.kt
+++ b/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/ButtonScopeTests.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton.test.onLoadingIndicator
+import org.junit.Rule
+import org.junit.Test
+
+internal class ButtonScopeTests {
+  private val scope = ButtonScope()
+
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun showsIndicatorWhenContentIsLoading() {
+    with(composeRule) {
+      setContent { scope.Loadable {} }
+      scope.load { onLoadingIndicator().assertIsDisplayed() }
+    }
+  }
+
+  @Test
+  fun showsContentBeforeLoading() {
+    with(composeRule) {
+      setContent { scope.Loadable { Text("☀️") } }
+      onNodeWithText("☀️").assertIsDisplayed()
+      scope.load {}
+    }
+  }
+
+  @Test
+  fun showsContentAfterLoading() {
+    with(composeRule) {
+      setContent { scope.Loadable { Text("☀️") } }
+      scope.load {}
+      onNodeWithText("☀️").assertIsDisplayed()
+    }
+  }
+}

--- a/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton.test.onLoadingIndicator
+import org.junit.Rule
+import org.junit.Test
+
+internal class SemanticsNodeInteractionsProviderExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun findsLoadingIndicator() {
+    composeRule.setContent {
+      Button {
+        DisposableEffect(Unit) {
+          load()
+          onDispose {}
+        }
+
+        Loadable {}
+      }
+    }
+    composeRule.onLoadingIndicator().assertIsDisplayed()
+  }
+}

--- a/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/test/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/test/SemanticsNodeInteractionsProvider.extensions.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton.test
+
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.hasProgressBarRangeInfo
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton.ButtonScope
+
+/**
+ * [SemanticsNodeInteraction] of a [ButtonScope]'s [Content][ButtonScope.Loadable]'s
+ * [CircularProgressIndicator].
+ */
+internal fun SemanticsNodeInteractionsProvider.onLoadingIndicator(): SemanticsNodeInteraction {
+  return onNode(hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate))
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/SecondaryButton.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/SecondaryButton.kt
@@ -15,46 +15,46 @@
 
 package com.jeanbarrossilva.orca.platform.autos.kit.action.button
 
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.jeanbarrossilva.orca.platform.autos.colors.asColor
-import com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton.Button
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton.Button as _Button
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton.ButtonDefaults as _ButtonDefaults
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.button.ButtonBar
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 
 /**
- * [Button] that represents a primary action, performed or requested to be performed through
- * [onClick]; usually is placed on the bottom of the screen, filling its width.
+ * [Button][_Button] that executes a secondary action when clicked, and is usually preceded by a
+ * [PrimaryButton] within a [ButtonBar].
  *
  * @param onClick Callback called whenever it's clicked.
- * @param modifier [Modifier] to be applied to the underlying [ElevatedButton].
- * @param isEnabled Whether it can be interacted with.
+ * @param modifier [Modifier] to be applied to the underlying [_Button].
  * @param content Content to be placed inside of it; generally a [Text] that shortly explains the
  *   action performed by [onClick].
  */
 @Composable
-fun PrimaryButton(
+fun SecondaryButton(
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
-  isEnabled: Boolean = true,
   content: @Composable () -> Unit
 ) {
-  Button {
-    ElevatedButton(
+  _Button {
+    Button(
       onClick = { load(onClick) },
       modifier,
-      isEnabled,
-      _ButtonDefaults.shape,
+      shape = _ButtonDefaults.shape,
       colors =
-        ButtonDefaults.elevatedButtonColors(
-          AutosTheme.colors.primary.container.asColor,
-          AutosTheme.colors.primary.content.asColor,
-          AutosTheme.colors.disabled.container.asColor,
-          AutosTheme.colors.disabled.content.asColor
+        ButtonDefaults.buttonColors(
+          containerColor = AutosTheme.colors.placeholder.asColor,
+          contentColor = AutosTheme.colors.background.content.asColor
         ),
       contentPadding = _ButtonDefaults.padding
     ) {
@@ -63,28 +63,12 @@ fun PrimaryButton(
   }
 }
 
-/** Preview of a disabled [PrimaryButton]. */
 @Composable
 @MultiThemePreview
-private fun DisabledPrimaryButtonPreview() {
-  AutosTheme { PrimaryButton(isEnabled = false) }
-}
-
-/** Preview of an enabled [PrimaryButton]. */
-@Composable
-@MultiThemePreview
-private fun EnabledPrimaryButtonPreview() {
-  AutosTheme { PrimaryButton(isEnabled = true) }
-}
-
-/**
- * [Button] that represents a primary action; usually is placed on the bottom of the screen, filling
- * its width.
- *
- * @param isEnabled Whether it can be interacted with.
- * @param modifier [Modifier] to be applied to the underlying [ElevatedButton].
- */
-@Composable
-private fun PrimaryButton(isEnabled: Boolean, modifier: Modifier = Modifier) {
-  PrimaryButton(onClick = {}, modifier, isEnabled) { Text("Label") }
+private fun SecondaryButtonPreview() {
+  AutosTheme {
+    SecondaryButton(onClick = { runBlocking { delay(5.seconds) } }, Modifier.fillMaxWidth()) {
+      Text("Label")
+    }
+  }
 }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/Button.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/Button.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.orca.platform.autos.forms.asShape
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
+
+/** Default values of [Button]s. */
+internal object ButtonDefaults {
+  /** [Shape] by which a [Button] is clipped by default. */
+  val shape
+    @Composable get() = AutosTheme.forms.large.asShape
+
+  /** [PaddingValues] that pads the content of a [Button] by default. */
+  val padding
+    @Composable get() = PaddingValues(AutosTheme.spacings.large.dp)
+}
+
+/**
+ * Orca-specific button skeleton that provides a [ButtonScope] to its [content] through which the
+ * loading state of the [Composable] that composes this one can be managed.
+ *
+ * [ButtonScope] offers two methods suited for operations that are common to all Orca [Button]s:
+ * [ButtonScope.Loadable], by which the main, loaded content of the [Button] (i. e., its [Text]
+ * label) will be shown; and [ButtonScope.load], that indicates whether the action for which the
+ * [Button] is is currently being executed, replacing the content specified within the
+ * [ButtonScope.Loadable] by a loading indicator until it has finished.
+ *
+ * @param content Content to be shown, with the [ButtonScope] by which common operations can be
+ *   performed.
+ */
+@Composable
+internal fun Button(content: @Composable ButtonScope.() -> Unit) {
+  remember(::ButtonScope).content()
+}
+
+/** Preview of [Button] whose content is loading. */
+@Composable
+@MultiThemePreview
+private fun LoadingButtonPreview() {
+  AutosTheme { Button { load { Loadable {} } } }
+}
+
+/** Preview of [Button] whose content is loaded. */
+@Composable
+@MultiThemePreview
+private fun LoadedButtonPreview() {
+  AutosTheme { Button { Loadable { Text("Hello, world!") } } }
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/ButtonScope.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/ButtonScope.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.dp
+
+/**
+ * Scope through which the content of a [Button] can be loaded.
+ *
+ * @see load
+ * @see Loadable
+ */
+internal class ButtonScope {
+  /** Whether the content is currently loading. */
+  private var isLoading by mutableStateOf(false)
+
+  /**
+   * Loads until the [action] finishes running.
+   *
+   * @param action Callback that executes the operation that is indicated by the loading.
+   */
+  inline fun load(action: () -> Unit) {
+    load()
+    action()
+    isLoading = false
+  }
+
+  /** Loads indefinitely. */
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  fun load() {
+    isLoading = true
+  }
+
+  /**
+   * [Composable] that shows either the [content] or a [CircularProgressIndicator] if this
+   * [ButtonScope] is currently loading.
+   *
+   * @param content [Composable] to be shown when the loading has finished.
+   */
+  @Composable
+  fun Loadable(content: @Composable () -> Unit) {
+    if (isLoading) {
+      CircularProgressIndicator(
+        Modifier.size(17.4.dp),
+        LocalContentColor.current,
+        strokeCap = StrokeCap.Round
+      )
+    } else {
+      ProvideTextStyle(LocalTextStyle.current.copy(color = LocalContentColor.current)) { content() }
+    }
+  }
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
@@ -19,7 +19,10 @@ import androidx.annotation.RestrictTo
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.LocalContentColor
@@ -33,11 +36,13 @@ import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.orca.autos.forms.Form
 import com.jeanbarrossilva.orca.platform.autos.R
 import com.jeanbarrossilva.orca.platform.autos.borders.asBorderStroke
 import com.jeanbarrossilva.orca.platform.autos.colors.asColor
@@ -101,7 +106,8 @@ fun TextField(
   label: @Composable () -> Unit
 ) {
   val context = LocalContext.current
-  val shape = AutosTheme.forms.large.asShape
+  val form = AutosTheme.forms.large as Form.PerCorner
+  val shape = remember(form, form::asShape)
   val errorMessages =
     errorDispatcher.messages.joinToString("\n") {
       context.getString(R.string.platform_ui_text_field_consecutive_error_message, it)
@@ -113,37 +119,40 @@ fun TextField(
     onDispose {}
   }
 
-  Column(verticalArrangement = Arrangement.spacedBy(AutosTheme.spacings.medium.dp)) {
-    TextField(
-      text,
-      onTextChange,
-      modifier.border(
-        AutosTheme.borders.default.asBorderStroke.width,
-        AutosTheme.borders.default.asBorderStroke.brush,
-        shape
-      ),
-      label = {
-        val color =
-          if (containsErrors) {
-            AutosTheme.colors.error.container.asColor
-          } else {
-            LocalContentColor.current
-          }
-        val style = LocalTextStyle.current.copy(color = color)
-        ProvideTextStyle(style) { label() }
-      },
-      isError = containsErrors,
-      keyboardOptions = keyboardOptions,
-      keyboardActions = keyboardActions,
-      singleLine = isSingleLined,
-      shape = shape,
-      colors = _TextFieldDefaults.colors()
-    )
+  Column(modifier, Arrangement.spacedBy(AutosTheme.spacings.medium.dp)) {
+    BoxWithConstraints {
+      TextField(
+        text,
+        onTextChange,
+        Modifier.border(
+            AutosTheme.borders.default.asBorderStroke.width,
+            AutosTheme.borders.default.asBorderStroke.brush,
+            shape
+          )
+          .width(maxWidth),
+        label = {
+          val color =
+            if (containsErrors) {
+              AutosTheme.colors.error.container.asColor
+            } else {
+              LocalContentColor.current
+            }
+          val style = LocalTextStyle.current.copy(color = color)
+          ProvideTextStyle(style) { label() }
+        },
+        isError = containsErrors,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = isSingleLined,
+        shape = shape,
+        colors = _TextFieldDefaults.colors()
+      )
+    }
 
     AnimatedVisibility(visible = containsErrors) {
       Text(
         errorMessages,
-        Modifier.testTag(TEXT_FIELD_ERRORS_TAG),
+        Modifier.padding(start = form.bottomStart.dp).testTag(TEXT_FIELD_ERRORS_TAG),
         AutosTheme.colors.error.container.asColor
       )
     }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/button/ButtonBar.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/button/ButtonBar.kt
@@ -32,10 +32,13 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.orca.platform.autos.borders.asBorderStroke
 import com.jeanbarrossilva.orca.platform.autos.colors.asColor
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.PrimaryButton
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.SecondaryButton
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton.Button
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.button.placement.Orientation
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.button.placement.height
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.button.placement.mapToPlacement
@@ -48,6 +51,13 @@ internal const val BUTTON_BAR_TAG = "button-bar"
 
 /** Tag that identifies a [ButtonBar]'s [Divider] for testing purposes. */
 internal const val BUTTON_BAR_DIVIDER_TAG = "button-bar-divider"
+
+/** Default values of a [ButtonBar]. */
+object ButtonBarDefaults {
+  /** Amount of [Dp]s by which a [ButtonBar]'s [Button]s are spaced. */
+  val spacing
+    @Composable get() = AutosTheme.spacings.small.dp
+}
 
 /**
  * Bar for housing a [PrimaryButton].
@@ -94,7 +104,7 @@ private fun ButtonBar(
   val border = AutosTheme.borders.default.asBorderStroke
   val borderStrokeWidth by
     animateDpAsState(if (isHighlighted) border.width else (-1).dp, label = "BorderStrokeWidth")
-  val spacing = AutosTheme.spacings.medium.dp
+  val spacing = ButtonBarDefaults.spacing
   val spacingInPx = remember(density, spacing) { with(density) { spacing.roundToPx() } }
   val containerColor by
     animateColorAsState(
@@ -119,7 +129,9 @@ private fun ButtonBar(
       val orientation = Orientation.VERTICAL
       val placements = measurables.mapToPlacement(constraints, orientation, spacingInPx)
 
-      layout(constraints.maxWidth, placements.height) { place(placements, orientation) }
+      layout(constraints.maxWidth, placements.height + spacingInPx) {
+        place(placements, orientation)
+      }
     }
   }
 }
@@ -132,7 +144,7 @@ private fun ButtonBar(
  */
 @Composable
 internal fun ButtonBar(lazyListState: LazyListState, modifier: Modifier = Modifier) {
-  ButtonBar(lazyListState, modifier) { PrimaryButton(onClick = {}) { Text("Label") } }
+  ButtonBar(lazyListState, modifier) { SampleContent() }
 }
 
 /** Preview of an idle [ButtonBar]. */
@@ -157,5 +169,12 @@ private fun HighlightedButtonBarPreview() {
  */
 @Composable
 private fun ButtonBar(isHighlighted: Boolean, modifier: Modifier = Modifier) {
-  ButtonBar(isHighlighted, modifier) { PrimaryButton(onClick = {}) { Text("Label") } }
+  ButtonBar(isHighlighted, modifier) { SampleContent() }
+}
+
+/** Sample [Button]s for a [ButtonBar]. */
+@Composable
+private fun SampleContent() {
+  PrimaryButton(onClick = {}) { Text("Primary") }
+  SecondaryButton(onClick = {}) { Text("Secondary") }
 }

--- a/platform/autos/src/test/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/ButtonScopeTests.kt
+++ b/platform/autos/src/test/java/com/jeanbarrossilva/orca/platform/autos/kit/action/button/skeleton/ButtonScopeTests.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.action.button.skeleton
+
+import assertk.assertThat
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+internal class ButtonScopeTests {
+  private val scope = ButtonScope()
+
+  @Test
+  fun runsCallbackWhenLoading() {
+    var hasOnClickBeenRun = false
+    scope.load { hasOnClickBeenRun = true }
+    assertThat(hasOnClickBeenRun).isTrue()
+  }
+}


### PR DESCRIPTION
Removes the clickable link-like text that asks what an instance is and places a secondary button in the button bar for when the user doesn't have an account, taking them to Mastodon's blog article that explains how the platform works.

<img src="https://github.com/the-orca-app/android/assets/38408390/5a2af2bc-0a9d-4016-b93d-41f7faccefa3" width="256" />
<img src="https://github.com/the-orca-app/android/assets/38408390/13da0e71-c8c1-47c4-a22a-cf3ec40534b2" width="256" />