### PR TITLE
Edge-to-edge gallery

### DIFF
--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivityTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivityTests.kt
@@ -15,8 +15,16 @@
 
 package com.jeanbarrossilva.orca.feature.gallery
 
+import android.util.TypedValue
+import android.view.WindowInsets
 import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.orca.feature.gallery.test.activity.TestGalleryModule
 import com.jeanbarrossilva.orca.feature.gallery.test.launchGalleryActivity
@@ -29,14 +37,44 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class GalleryActivityTests {
+  private val context
+    get() = InstrumentationRegistry.getInstrumentation().context
+
   @get:Rule
   val injectorRule = InjectorTestRule { register(TestGalleryModule.boundTo<GalleryModule, _>()) }
 
   @get:Rule val composeRule = createEmptyComposeRule()
 
   @Test
+  fun isEdgeToEdge() {
+    val density = Density(context)
+    val resources = context.resources
+    var systemBarsHeight = Dp.Unspecified
+    val actionBarHeight =
+      TypedValue()
+        .also { context.theme.resolveAttribute(android.R.attr.actionBarSize, it, true) }
+        .let { resources.getDimensionPixelSize(it.resourceId) }
+        .let { with(density) { it.toDp() } }
+    val configuration = resources.configuration
+    launchGalleryActivity().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.windowManager
+          ?.currentWindowMetrics
+          ?.windowInsets
+          ?.getInsets(WindowInsets.Type.systemBars())
+          ?.run { systemBarsHeight = with(density) { (top + bottom).toDp() } }
+      }
+      composeRule
+        .onRoot()
+        .assertWidthIsEqualTo(configuration.screenWidthDp.dp)
+        .assertHeightIsEqualTo(
+          configuration.screenHeightDp.dp + (systemBarsHeight - actionBarHeight)
+        )
+    }
+  }
+
+  @Test
   fun describesEachPage() {
-    val context = InstrumentationRegistry.getInstrumentation().context
     launchGalleryActivity().use {
       with(composeRule) {
         onPager().performScrollToEachPage {

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivity.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivity.kt
@@ -17,6 +17,8 @@ package com.jeanbarrossilva.orca.feature.gallery
 
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -44,6 +46,11 @@ class GalleryActivity internal constructor() : ComposableActivity() {
     viewModels<GalleryViewModel> {
       GalleryViewModel.createFactory(application, module.postProvider(), postID)
     }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
+  }
 
   @Composable
   override fun Content() {

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/Gallery.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/Gallery.kt
@@ -22,7 +22,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.mandatorySystemGesturesPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
@@ -131,7 +131,7 @@ private fun Gallery(
       }
     }
 
-  Box(modifier.background(Color.Black).systemBarsPadding()) {
+  Box(modifier.background(Color.Black).mandatorySystemGesturesPadding().fillMaxHeight()) {
     HorizontalPager(
       pagerState,
       Modifier.fillMaxHeight().testTag(GALLERY_PAGER_TAG),

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/Gallery.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/Gallery.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
@@ -130,7 +131,7 @@ private fun Gallery(
       }
     }
 
-  Box(modifier.background(Color.Black)) {
+  Box(modifier.background(Color.Black).systemBarsPadding()) {
     HorizontalPager(
       pagerState,
       Modifier.fillMaxHeight().testTag(GALLERY_PAGER_TAG),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,7 @@ orca-setup-kotlin = { id = "com.jeanbarrossilva.orca.setup.kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
 [versions]
-android-activity = "1.7.2"
+android-activity = "1.8.2"
 android-compose = "1.5.3"
 android-fragment = "1.6.1"
 android-plugin = "8.2.0"


### PR DESCRIPTION
Hides system bars in a post's gallery.

<img src="https://github.com/the-orca-app/android/assets/38408390/a76c6ae4-9dcd-48a7-af70-f388579b2f7d" width="256" />
<img src="https://github.com/the-orca-app/android/assets/38408390/07a7e605-b34a-4b97-aff8-ea926693fc1e" width="256" />