### PR TITLE
Add `:platform:testing`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ android-compose-foundation = { group = "androidx.compose.foundation", name = "fo
 android-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "android-compose" }
 android-compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended", version = "1.5.1" }
 android-compose-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.1.2" }
+android-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "android-compose" }
 android-compose-ui-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "android-compose" }
 android-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "android-compose" }
 android-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "android-compose" }
@@ -60,7 +61,6 @@ spotless = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", v
 time4j = { group = "net.time4j", name = "time4j-android", version = "4.8-2021a" }
 turbine = { group = "app.cash.turbine", name = "turbine", version = "1.0.0" }
 zoomable = { group = "net.engawapg.lib", name = "zoomable", version = "1.6.0-beta2" }
-androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-plugin" }
@@ -98,4 +98,3 @@ kotlin-symbolProcessor = "1.9.10-1.0.13"
 ktor = "2.3.2"
 loadable = "1.6.9"
 spotless = "6.22.0"
-junit = "1.1.5"

--- a/platform/testing/build.gradle.kts
+++ b/platform/testing/build.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+}
+
+android {
+  defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  packagingOptions.resources.excludes +=
+    arrayOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md")
+}
+
+dependencies {
+  androidTestImplementation(libs.android.test.runner)
+  androidTestImplementation(libs.assertk)
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.kotlin.reflect)
+  androidTestImplementation(libs.mockk)
+
+  implementation(libs.android.compose.ui)
+  implementation(libs.android.test.core)
+}

--- a/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/InstrumentationExtensionsTests.kt
+++ b/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/InstrumentationExtensionsTests.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing
+
+import androidx.test.platform.app.InstrumentationRegistry
+import assertk.assertThat
+import assertk.assertions.isSameAs
+import org.junit.Test
+
+internal class InstrumentationExtensionsTests {
+  @Test
+  fun contextIsThatOfInstrumentationFromRegistry() {
+    assertThat(context).isSameAs(InstrumentationRegistry.getInstrumentation().context)
+  }
+}

--- a/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/IntExtensionsTests.kt
+++ b/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/IntExtensionsTests.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jeanbarrossilva.orca.platform.testing.test.R
+import org.junit.Test
+
+internal class IntExtensionsTests {
+  @Test
+  fun getsStringFromResourceID() {
+    assertThat(R.string.string.asString()).isEqualTo("5️⃣👍🏽🏞️👩🏻‍💻⏩🎇")
+  }
+}

--- a/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/screen/DimensionTests.kt
+++ b/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/screen/DimensionTests.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing.screen
+
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jeanbarrossilva.orca.platform.testing.context
+import org.junit.Test
+
+internal class DimensionTests {
+  @Test
+  fun createsWidthFromResources() {
+    val width = Screen.Dimension.width(context.resources)
+    assertThat(width.inPixels).isEqualTo(context.resources.displayMetrics.widthPixels)
+    assertThat(width.inDps).isEqualTo(context.resources.configuration.screenWidthDp.dp)
+  }
+
+  @Test
+  fun createsHeightFromResources() {
+    val height = Screen.Dimension.height(context.resources)
+    assertThat(height.inPixels).isEqualTo(context.resources.displayMetrics.heightPixels)
+    assertThat(height.inDps).isEqualTo(context.resources.configuration.screenHeightDp.dp)
+  }
+}

--- a/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/screen/ScreenTests.kt
+++ b/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/screen/ScreenTests.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing.screen
+
+import android.content.res.AssetManager
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.util.DisplayMetrics
+import androidx.compose.ui.unit.dp
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import com.jeanbarrossilva.orca.platform.testing.context
+import io.mockk.mockkObject
+import io.mockk.verify
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.staticFunctions
+import org.junit.Test
+
+internal class ScreenTests {
+  @Test
+  fun createsScreenFromResources() {
+    assertThat(
+        Screen.from(
+          @Suppress("DEPRECATION")
+          Resources(
+              AssetManager::class
+                .staticFunctions
+                .filterIsInstance<KFunction<AssetManager>>()
+                .single { it.name == "getSystem" }
+                .call(),
+              DisplayMetrics(),
+              Configuration()
+            )
+            .apply {
+              displayMetrics.widthPixels = 2
+              displayMetrics.heightPixels = 8
+              configuration.screenWidthDp = 4
+              configuration.screenHeightDp = 16
+            }
+        )
+      )
+      .all {
+        prop("width.inPixels") { it.width.inPixels }.isEqualTo(2)
+        prop("width.inDps") { it.width.inDps }.isEqualTo(4.dp)
+        prop("height.inPixels") { it.height.inPixels }.isEqualTo(8)
+        prop("height.inDps") { it.height.inDps }.isEqualTo(16.dp)
+      }
+  }
+
+  @Test
+  fun creatingScreenFromContextDelegatesToDoingSoWithItsResources() {
+    mockkObject(Screen.Companion) {
+      Screen.from(context)
+      verify { Screen.from(context.resources) }
+    }
+  }
+}

--- a/platform/testing/src/androidTest/res/values/strings.xml
+++ b/platform/testing/src/androidTest/res/values/strings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2023 Orca
+  ~
+  ~ This program is free software: you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  ~ even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with this program. If
+  ~ not, see https://www.gnu.org/licenses.
+  -->
+
+<resources>
+    <string name="string">5️⃣👍🏽🏞️👩🏻‍💻⏩🎇</string>
+</resources>

--- a/platform/testing/src/main/AndroidManifest.xml
+++ b/platform/testing/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright © 2023 Orca
+  ~
+  ~ This program is free software: you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  ~ even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with this program. If
+  ~ not, see https://www.gnu.org/licenses.
+  -->
+
+<manifest />

--- a/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/Instrumentation.extensions.kt
+++ b/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/Instrumentation.extensions.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing
+
+import android.app.Instrumentation
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+
+/**
+ * [InstrumentationRegistry]'s [Instrumentation]'s [Context].
+ *
+ * @see InstrumentationRegistry.getInstrumentation
+ * @see Instrumentation.getContext
+ */
+val context: Context
+  get() = InstrumentationRegistry.getInstrumentation().context

--- a/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/Int.extensions.kt
+++ b/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/Int.extensions.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing
+
+import androidx.annotation.StringRes
+
+/**
+ * Gets the [String] from this resource ID.
+ *
+ * @param format [String] by which arguments in the [String] will be replaced.
+ */
+fun @receiver:StringRes Int.asString(vararg format: String): String {
+  return context.getString(this, *format)
+}

--- a/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/screen/Screen.kt
+++ b/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/screen/Screen.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing.screen
+
+import android.content.Context
+import android.content.res.Resources
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import java.util.Objects
+
+/**
+ * Relevant information about the display of the device in which the testing is taking place.
+ *
+ * @param width [Dimension] for how wide the display is.
+ * @param height [Dimension] for how tall the display is.
+ */
+class Screen private constructor(val width: Dimension, val height: Dimension) {
+  override fun equals(other: Any?): Boolean {
+    return other is Screen && width == other.width && height == other.height
+  }
+
+  override fun hashCode(): Int {
+    return Objects.hash(width, height)
+  }
+
+  /**
+   * Offers the value that represents the size of one of the axes of the [Screen] in multiple units.
+   *
+   * @param inPixels Value of this [Dimension] in pixels.
+   * @param inDps Value of this [Dimension] in [Dp]s.
+   */
+  class Dimension private constructor(val inPixels: Int, val inDps: Dp) {
+    override fun equals(other: Any?): Boolean {
+      return other is Dimension && inPixels == other.inPixels && inDps == other.inDps
+    }
+
+    override fun hashCode(): Int {
+      return Objects.hash(inPixels, inDps)
+    }
+
+    companion object {
+      /**
+       * Creates a width [Dimension].
+       *
+       * @param resources [Resources] from which the value in pixels and in [Dp]s will be obtained.
+       */
+      internal fun width(resources: Resources): Dimension {
+        return Dimension(
+          resources.displayMetrics.widthPixels,
+          resources.configuration.screenWidthDp.dp
+        )
+      }
+
+      /**
+       * Creates a height [Dimension].
+       *
+       * @param resources [Resources] from which the value in pixels and in [Dp]s will be obtained.
+       */
+      internal fun height(resources: Resources): Dimension {
+        return Dimension(
+          resources.displayMetrics.heightPixels,
+          resources.configuration.screenHeightDp.dp
+        )
+      }
+    }
+  }
+
+  companion object {
+    /**
+     * Obtains test-tailored information about the display of the device.
+     *
+     * @param context [Context] whose [Resources] will provide the dimensions.
+     */
+    fun from(context: Context): Screen {
+      return from(context.resources)
+    }
+
+    /**
+     * Obtains test-tailored information about the display of the device.
+     *
+     * @param resources [Resources] by which the dimensions will be provided.
+     */
+    internal fun from(resources: Resources): Screen {
+      val width = Dimension.width(resources)
+      val height = Dimension.height(resources)
+      return Screen(width, height)
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,6 +46,7 @@ include(
   ":platform:cache",
   ":platform:autos-test",
   ":platform:intents",
+  ":platform:testing",
   ":platform:ui",
   ":platform:ui-test",
   ":std:buildable",


### PR DESCRIPTION
Adds a module that provides API for facilitating the retrieval of commonly utilized information within an instrumentation test environment, such as the [`Context`](https://developer.android.com/reference/android/content/Context), the dimensions of the display and a way to obtain a [`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string) from its resource identifier.