### PR TITLE
Use `:platform:testing` API

### DIFF
--- a/core/mastodon/build.gradle.kts
+++ b/core/mastodon/build.gradle.kts
@@ -43,6 +43,7 @@ android {
 dependencies {
   androidTestImplementation(project(":platform:autos-test"))
   androidTestImplementation(project(":platform:intents"))
+  androidTestImplementation(project(":platform:testing"))
   androidTestImplementation(project(":std:injector-test"))
   androidTestImplementation(libs.android.compose.ui.test.junit)
   androidTestImplementation(libs.android.test.core)

--- a/core/mastodon/src/androidTest/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorizationActivityTests.kt
+++ b/core/mastodon/src/androidTest/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorizationActivityTests.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
-import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
@@ -33,15 +32,14 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.SampleTerm
 import com.jeanbarrossilva.orca.core.sample.instance.domain.sample
 import com.jeanbarrossilva.orca.ext.intents.intendBrowsingTo
 import com.jeanbarrossilva.orca.platform.autos.test.kit.input.text.onTextFieldErrors
+import com.jeanbarrossilva.orca.platform.testing.asString
+import com.jeanbarrossilva.orca.platform.testing.context
 import com.jeanbarrossilva.orca.platform.ui.core.sample
 import com.jeanbarrossilva.orca.std.injector.test.InjectorTestRule
 import org.junit.Rule
 import org.junit.Test
 
 internal class MastodonAuthorizationActivityTests {
-  private val context
-    get() = InstrumentationRegistry.getInstrumentation().context
-
   @get:Rule
   val injectorRule = InjectorTestRule {
     register(
@@ -58,43 +56,37 @@ internal class MastodonAuthorizationActivityTests {
   @Test
   fun showsErrorWhenSigningInWithBlankDomain() {
     composeRule
-      .onNodeWithText(context.getString(R.string.core_http_authorization_domain))
+      .onNodeWithText(R.string.core_http_authorization_domain.asString())
       .apply { performTextInput(" ") }
       .performImeAction()
     composeRule
       .onTextFieldErrors()
       .assertTextEquals(
-        context.getString(
-          com.jeanbarrossilva.orca.platform.autos.R.string
-            .platform_ui_text_field_consecutive_error_message,
-          context.getString(R.string.core_http_authorization_empty_domain)
-        )
+        com.jeanbarrossilva.orca.platform.autos.R.string
+          .platform_ui_text_field_consecutive_error_message
+          .asString(R.string.core_http_authorization_empty_domain.asString())
       )
   }
 
   @Test
   fun showsErrorWhenSigningInWithInvalidDomain() {
     composeRule
-      .onNodeWithText(context.getString(R.string.core_http_authorization_domain))
+      .onNodeWithText(R.string.core_http_authorization_domain.asString())
       .apply { performTextInput("1️⃣🏛️🖼️") }
       .performImeAction()
     composeRule
       .onTextFieldErrors()
       .assertTextEquals(
-        context.getString(
-          com.jeanbarrossilva.orca.platform.autos.R.string
-            .platform_ui_text_field_consecutive_error_message,
-          context.getString(R.string.core_http_authorization_invalid_domain)
-        )
+        com.jeanbarrossilva.orca.platform.autos.R.string
+          .platform_ui_text_field_consecutive_error_message
+          .asString(R.string.core_http_authorization_invalid_domain.asString())
       )
   }
 
   @Test
   fun browsesToHelpArticle() {
     intendBrowsingTo("${MastodonAuthorizationActivity.helpUri}") {
-      composeRule
-        .onNodeWithText(context.getString(R.string.core_http_authorization_help))
-        .performClick()
+      composeRule.onNodeWithText(R.string.core_http_authorization_help.asString()).performClick()
     }
   }
 
@@ -102,7 +94,7 @@ internal class MastodonAuthorizationActivityTests {
   fun browsesToInstanceWhenSigningInWithValidDomain() {
     intendBrowsingTo("${MastodonAuthorizationViewModel.createURL(context, Domain.sample)}") {
       composeRule
-        .onNodeWithText(context.getString(R.string.core_http_authorization_domain))
+        .onNodeWithText(R.string.core_http_authorization_domain.asString())
         .apply { performTextInput("${Domain.sample}") }
         .performImeAction()
     }

--- a/core/shared-preferences/build.gradle.kts
+++ b/core/shared-preferences/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 
 dependencies {
   androidTestImplementation(project(":core-test"))
+  androidTestImplementation(project(":platform:testing"))
   androidTestImplementation(libs.android.test.runner)
   androidTestImplementation(libs.junit)
   androidTestImplementation(libs.kotlin.coroutines.test)

--- a/core/shared-preferences/build.gradle.kts
+++ b/core/shared-preferences/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
   implementation(project(":core"))
   implementation(libs.android.core)
+  implementation(libs.android.lifecycle.runtime)
   implementation(libs.kotlin.coroutines.android)
   implementation(libs.kotlin.serialization.json)
 }

--- a/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/test/SharedPreferencesCoreTestRule.kt
+++ b/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/test/SharedPreferencesCoreTestRule.kt
@@ -15,16 +15,13 @@
 
 package com.jeanbarrossilva.orca.core.sharedpreferences.actor.test
 
-import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.TermMuter
 import com.jeanbarrossilva.orca.core.sharedpreferences.actor.SharedPreferencesActorProvider
 import com.jeanbarrossilva.orca.core.sharedpreferences.feed.profile.post.content.SharedPreferencesTermMuter
+import com.jeanbarrossilva.orca.platform.testing.context
 import org.junit.rules.ExternalResource
 
 internal class SharedPreferencesCoreTestRule : ExternalResource() {
-  private val context
-    get() = InstrumentationRegistry.getInstrumentation().context
-
   lateinit var actorProvider: SharedPreferencesActorProvider
     private set
 

--- a/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/feed/profile/post/content/SharedPreferencesTermMuterTests.kt
+++ b/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/feed/profile/post/content/SharedPreferencesTermMuterTests.kt
@@ -15,9 +15,9 @@
 
 package com.jeanbarrossilva.orca.core.sharedpreferences.feed.profile.post.content
 
-import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import com.jeanbarrossilva.orca.core.sharedpreferences.actor.test.SharedPreferencesCoreTestRule
+import com.jeanbarrossilva.orca.platform.testing.context
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -25,9 +25,6 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class SharedPreferencesTermMuterTests {
-  private val context
-    get() = InstrumentationRegistry.getInstrumentation().context
-
   @get:Rule val coreRule = SharedPreferencesCoreTestRule()
 
   @Test

--- a/feature/feed/build.gradle.kts
+++ b/feature/feed/build.gradle.kts
@@ -27,6 +27,7 @@ android {
 
 dependencies {
   androidTestImplementation(project(":core:sample-test"))
+  androidTestImplementation(project(":platform:testing"))
   androidTestImplementation(project(":platform:ui-test"))
   androidTestImplementation(project(":std:injector-test"))
   androidTestImplementation(libs.android.compose.ui.test.junit)

--- a/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/FeedActivity.kt
+++ b/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/FeedActivity.kt
@@ -17,8 +17,8 @@ package com.jeanbarrossilva.orca.feature.feed.test
 
 import android.content.Intent
 import androidx.navigation.NavGraphBuilder
-import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.orca.feature.feed.FeedFragment
+import com.jeanbarrossilva.orca.platform.testing.context
 import com.jeanbarrossilva.orca.platform.ui.core.Intent
 import com.jeanbarrossilva.orca.platform.ui.test.core.SingleFragmentActivity
 
@@ -31,7 +31,6 @@ internal class FeedActivity : SingleFragmentActivity() {
 
   companion object {
     fun getIntent(userID: String): Intent {
-      val context = InstrumentationRegistry.getInstrumentation().context
       return Intent<FeedActivity>(context, FeedFragment.USER_ID_KEY to userID)
     }
   }

--- a/feature/gallery/build.gradle.kts
+++ b/feature/gallery/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 
 dependencies {
   androidTestImplementation(project(":core:sample-test"))
+  androidTestImplementation(project(":platform:testing"))
   androidTestImplementation(project(":platform:ui-test"))
   androidTestImplementation(project(":std:injector-test"))
   androidTestImplementation(libs.android.compose.ui.test.junit)

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivityTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivityTests.kt
@@ -24,12 +24,13 @@ import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
-import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.orca.feature.gallery.test.activity.TestGalleryModule
 import com.jeanbarrossilva.orca.feature.gallery.test.launchGalleryActivity
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPager
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.performScrollToEachPage
+import com.jeanbarrossilva.orca.platform.testing.asString
+import com.jeanbarrossilva.orca.platform.testing.context
+import com.jeanbarrossilva.orca.platform.testing.screen.Screen
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.post.formatted
 import com.jeanbarrossilva.orca.std.injector.module.binding.boundTo
 import com.jeanbarrossilva.orca.std.injector.test.InjectorTestRule
@@ -37,9 +38,6 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class GalleryActivityTests {
-  private val context
-    get() = InstrumentationRegistry.getInstrumentation().context
-
   @get:Rule
   val injectorRule = InjectorTestRule { register(TestGalleryModule.boundTo<GalleryModule, _>()) }
 
@@ -47,6 +45,7 @@ internal class GalleryActivityTests {
 
   @Test
   fun isEdgeToEdge() {
+    val screen = Screen.from(context)
     val density = Density(context)
     val resources = context.resources
     var systemBarsHeight = Dp.Unspecified
@@ -55,7 +54,6 @@ internal class GalleryActivityTests {
         .also { context.theme.resolveAttribute(android.R.attr.actionBarSize, it, true) }
         .let { resources.getDimensionPixelSize(it.resourceId) }
         .let { with(density) { it.toDp() } }
-    val configuration = resources.configuration
     launchGalleryActivity().use { scenario ->
       scenario.onActivity { activity ->
         activity.windowManager
@@ -66,10 +64,8 @@ internal class GalleryActivityTests {
       }
       composeRule
         .onRoot()
-        .assertWidthIsEqualTo(configuration.screenWidthDp.dp)
-        .assertHeightIsEqualTo(
-          configuration.screenHeightDp.dp + (systemBarsHeight - actionBarHeight)
-        )
+        .assertWidthIsEqualTo(screen.width.inDps)
+        .assertHeightIsEqualTo(screen.width.inDps + (systemBarsHeight - actionBarHeight))
     }
   }
 
@@ -78,9 +74,7 @@ internal class GalleryActivityTests {
     launchGalleryActivity().use {
       with(composeRule) {
         onPager().performScrollToEachPage {
-          assertContentDescriptionEquals(
-            context.getString(R.string.feature_gallery_attachment, it.formatted)
-          )
+          assertContentDescriptionEquals(R.string.feature_gallery_attachment.asString(it.formatted))
         }
       }
     }

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivityTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivityTests.kt
@@ -30,7 +30,7 @@ import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPager
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.performScrollToEachPage
 import com.jeanbarrossilva.orca.platform.testing.asString
 import com.jeanbarrossilva.orca.platform.testing.context
-import com.jeanbarrossilva.orca.platform.testing.screen.Screen
+import com.jeanbarrossilva.orca.platform.testing.screen.screen
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.post.formatted
 import com.jeanbarrossilva.orca.std.injector.module.binding.boundTo
 import com.jeanbarrossilva.orca.std.injector.test.InjectorTestRule
@@ -45,7 +45,6 @@ internal class GalleryActivityTests {
 
   @Test
   fun isEdgeToEdge() {
-    val screen = Screen.from(context)
     val density = Density(context)
     val resources = context.resources
     var systemBarsHeight = Dp.Unspecified
@@ -65,7 +64,7 @@ internal class GalleryActivityTests {
       composeRule
         .onRoot()
         .assertWidthIsEqualTo(screen.width.inDps)
-        .assertHeightIsEqualTo(screen.width.inDps + (systemBarsHeight - actionBarHeight))
+        .assertHeightIsEqualTo(screen.height.inDps + (systemBarsHeight - actionBarHeight))
     }
   }
 

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ActivityScenario.extensions.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ActivityScenario.extensions.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.launchActivity
-import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.samples
@@ -30,6 +29,7 @@ import com.jeanbarrossilva.orca.core.sample.image.CoverImageSource
 import com.jeanbarrossilva.orca.core.sample.test.feed.profile.post.sample
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
 import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.platform.testing.context
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.post.formatted
 import com.jeanbarrossilva.orca.platform.ui.core.image.createSample
 import com.jeanbarrossilva.orca.std.image.compose.ComposableImageLoader
@@ -58,7 +58,6 @@ internal fun launchGalleryActivity(
     )
   }
 ): ActivityScenario<GalleryActivity> {
-  val context = InstrumentationRegistry.getInstrumentation().context
   val intent = GalleryActivity.getIntent(context, postID, entrypointIndex, secondary)
   return launchActivity<GalleryActivity>(intent).onActivity { it.setEntrypoint(entrypoint) }
 }

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/SemanticsNodeInteractionExtensionsTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/SemanticsNodeInteractionExtensionsTests.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
-import androidx.test.platform.app.InstrumentationRegistry
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
@@ -39,6 +38,7 @@ import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPager
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.performScrollToEachPage
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.performScrollToPageAt
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import com.jeanbarrossilva.orca.platform.testing.asString
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.post.formatted
 import org.junit.Rule
 import org.junit.Test
@@ -73,30 +73,24 @@ internal class SemanticsNodeInteractionExtensionsTests {
 
   @Test
   fun scrollsToPageOfGalleryPager() {
-    val context = InstrumentationRegistry.getInstrumentation().context
     composeRule
       .apply { setContent { AutosTheme { Gallery() } } }
       .run {
         onPager().performScrollToPageAt(0)
         onPage()
       }
-      .assertContentDescriptionEquals(
-        context.getString(R.string.feature_gallery_attachment, 2.formatted)
-      )
+      .assertContentDescriptionEquals(R.string.feature_gallery_attachment.asString(2.formatted))
   }
 
   @Test
   fun scrollsToEachPageOfGalleryPager() {
-    val context = InstrumentationRegistry.getInstrumentation().context
     var positions = IntRange.EMPTY
     composeRule
       .apply { setContent { AutosTheme { Gallery() } } }
       .run {
         onPager().performScrollToEachPage {
           positions = 1..it
-          assertContentDescriptionEquals(
-            context.getString(R.string.feature_gallery_attachment, it.formatted)
-          )
+          assertContentDescriptionEquals(R.string.feature_gallery_attachment.asString(it.formatted))
         }
       }
     assertThat(positions).isEqualTo(1..Attachment.samples.size.inc())

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/test/zoom/SemanticsMatcher.extensions.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/test/zoom/SemanticsMatcher.extensions.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onParent
 import androidx.compose.ui.unit.Density
-import androidx.test.platform.app.InstrumentationRegistry
+import com.jeanbarrossilva.orca.platform.testing.context
 
 /**
  * [SemanticsMatcher] that matches a [SemanticsNode] whose [predicate] is `true`.
@@ -38,7 +38,6 @@ internal fun unclippedBoundsMatcher(
   predicate: (parentBounds: Rect, bounds: Rect) -> Boolean
 ): SemanticsMatcher {
   return SemanticsMatcher(description) {
-    val context = InstrumentationRegistry.getInstrumentation().context
     val density = Density(context)
     val bounds = with(density) { getUnclippedBoundsInRoot().toRect() }
     val parentBounds = with(density) { onParent().getUnclippedBoundsInRoot().toRect() }

--- a/feature/profile-details/build.gradle.kts
+++ b/feature/profile-details/build.gradle.kts
@@ -30,6 +30,7 @@ android {
 
 dependencies {
   androidTestImplementation(project(":core:sample-test"))
+  androidTestImplementation(project(":platform:testing"))
   androidTestImplementation(project(":platform:ui-test"))
   androidTestImplementation(project(":std:injector-test"))
   androidTestImplementation(libs.android.compose.ui.test.junit)

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsTests.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsTests.kt
@@ -22,8 +22,7 @@ import androidx.compose.ui.test.performScrollToIndex
 import com.jeanbarrossilva.loadable.list.toListLoadable
 import com.jeanbarrossilva.loadable.list.toSerializableList
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
-import com.jeanbarrossilva.orca.platform.testing.context
-import com.jeanbarrossilva.orca.platform.testing.screen.Screen
+import com.jeanbarrossilva.orca.platform.testing.screen.screen
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.TIMELINE_TAG
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.post.PostPreview
 import com.jeanbarrossilva.orca.platform.ui.test.component.timeline.onTimeline
@@ -41,7 +40,7 @@ internal class ProfileDetailsTests {
       AutosTheme {
         ProfileDetails(
           postPreviewsLoadable =
-            List(size = Screen.from(context).height.inPixels) {
+            List(size = screen.height.inPixels) {
                 PostPreview.sample.copy(id = "${UUID.randomUUID()}")
               }
               .toSerializableList()

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsTests.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsTests.kt
@@ -19,10 +19,11 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollToIndex
-import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.loadable.list.toListLoadable
 import com.jeanbarrossilva.loadable.list.toSerializableList
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import com.jeanbarrossilva.orca.platform.testing.context
+import com.jeanbarrossilva.orca.platform.testing.screen.Screen
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.TIMELINE_TAG
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.post.PostPreview
 import com.jeanbarrossilva.orca.platform.ui.test.component.timeline.onTimeline
@@ -36,13 +37,13 @@ internal class ProfileDetailsTests {
 
   @Test
   fun showsUsernameWhenScrollingPastHeader() {
-    val screenHeightInPx =
-      InstrumentationRegistry.getInstrumentation().context.resources.displayMetrics.heightPixels
     composeRule.setContent {
       AutosTheme {
         ProfileDetails(
           postPreviewsLoadable =
-            List(size = screenHeightInPx) { PostPreview.sample.copy(id = "${UUID.randomUUID()}") }
+            List(size = Screen.from(context).height.inPixels) {
+                PostPreview.sample.copy(id = "${UUID.randomUUID()}")
+              }
               .toSerializableList()
               .toListLoadable(),
           relativeTimeProvider = TestRelativeTimeProvider

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/ProfileDetailsActivity.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/ProfileDetailsActivity.kt
@@ -17,9 +17,9 @@ package com.jeanbarrossilva.orca.feature.profiledetails.test
 
 import android.content.Intent
 import androidx.navigation.NavGraphBuilder
-import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsFragment
 import com.jeanbarrossilva.orca.feature.profiledetails.navigation.BackwardsNavigationState
+import com.jeanbarrossilva.orca.platform.testing.context
 import com.jeanbarrossilva.orca.platform.ui.core.Intent
 import com.jeanbarrossilva.orca.platform.ui.test.core.SingleFragmentActivity
 
@@ -32,7 +32,6 @@ internal class ProfileDetailsActivity : SingleFragmentActivity() {
 
   companion object {
     fun getIntent(backwardsNavigationState: BackwardsNavigationState, id: String): Intent {
-      val context = InstrumentationRegistry.getInstrumentation().context
       return Intent<ProfileDetailsActivity>(
         context,
         ProfileDetailsFragment.BACKWARDS_NAVIGATION_STATE_KEY to backwardsNavigationState,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,8 @@ android-constraintlayout-compose = { group = "androidx.constraintlayout", name =
 android-core = { group = "androidx.core", name = "core-ktx", version = "1.12.0" }
 android-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "android-fragment" }
 android-fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "android-fragment" }
-android-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version = "2.6.2" }
+android-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "android-lifecycle" }
+android-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "android-lifecycle" }
 android-material = { group = "com.google.android.material", name = "material", version = "1.9.0" }
 android-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version = "2.7.3" }
 android-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-plugin" }
@@ -85,6 +86,7 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 android-activity = "1.8.2"
 android-compose = "1.5.3"
 android-fragment = "1.6.1"
+android-lifecycle = "2.6.2"
 android-plugin = "8.2.0"
 android-room = "2.5.2"
 android-sdk-min = "28"

--- a/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/screen/ScreenExtensionsTests.kt
+++ b/platform/testing/src/androidTest/java/com/jeanbarrossilva/orca/platform/testing/screen/ScreenExtensionsTests.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing.screen
+
+import com.jeanbarrossilva.orca.platform.testing.context
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Test
+
+internal class ScreenExtensionsTests {
+  @Test
+  fun getsScreenFromContext() {
+    mockkObject(Screen.Companion) {
+      screen
+      verify { Screen.from(context) }
+    }
+  }
+}

--- a/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/screen/Screen.extensions.kt
+++ b/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/screen/Screen.extensions.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.testing.screen
+
+import com.jeanbarrossilva.orca.platform.testing.context
+
+/** Test-tailored information about the display of the device. */
+val screen
+  get() = Screen.from(context)

--- a/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/screen/Screen.kt
+++ b/platform/testing/src/main/java/com/jeanbarrossilva/orca/platform/testing/screen/Screen.kt
@@ -84,7 +84,7 @@ class Screen private constructor(val width: Dimension, val height: Dimension) {
      *
      * @param context [Context] whose [Resources] will provide the dimensions.
      */
-    fun from(context: Context): Screen {
+    internal fun from(context: Context): Screen {
       return from(context.resources)
     }
 


### PR DESCRIPTION
Uses [`:platform:testing`](https://github.com/the-orca-app/android/tree/e4eaa30a625fc9187f08821a8340de6b5fefe40b/platform/testing) API at [`:core:mastodon`](https://github.com/the-orca-app/android/tree/e4eaa30a625fc9187f08821a8340de6b5fefe40b/core/mastodon), [`:core:shared-preferences`](https://github.com/the-orca-app/android/tree/e4eaa30a625fc9187f08821a8340de6b5fefe40b/core/shared-preferences), [`:feature:feed`](https://github.com/the-orca-app/android/tree/e4eaa30a625fc9187f08821a8340de6b5fefe40b/feature/feed), [`:feature:gallery`](https://github.com/the-orca-app/android/tree/e4eaa30a625fc9187f08821a8340de6b5fefe40b/feature/gallery) and [`feature:profile-details`](https://github.com/the-orca-app/android/tree/e4eaa30a625fc9187f08821a8340de6b5fefe40b/feature/profile-details).