### PR TITLE
Replace `:std:injector` injection lambda signature by a single type

### DIFF
--- a/app/src/demo/java/com/jeanbarrossilva/orca/app/demo/module/core/DemoCoreModule.kt
+++ b/app/src/demo/java/com/jeanbarrossilva/orca/app/demo/module/core/DemoCoreModule.kt
@@ -18,10 +18,11 @@ package com.jeanbarrossilva.orca.app.demo.module.core
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.SampleTermMuter
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal object DemoCoreModule :
   CoreModule(
-    { InstanceProvider.sample },
-    { InstanceProvider.sample.provide().authenticationLock },
-    { SampleTermMuter() }
+    injectionOf { InstanceProvider.sample },
+    injectionOf { InstanceProvider.sample.provide().authenticationLock },
+    injectionOf { SampleTermMuter() }
   )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainMastodonCoreModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainMastodonCoreModule.kt
@@ -25,10 +25,11 @@ import com.jeanbarrossilva.orca.core.sharedpreferences.actor.SharedPreferencesAc
 import com.jeanbarrossilva.orca.core.sharedpreferences.feed.profile.post.content.SharedPreferencesTermMuter
 import com.jeanbarrossilva.orca.std.image.compose.async.AsyncImageLoader
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal object MainMastodonCoreModule :
   MastodonCoreModule(
-    {
+    injectionOf {
       MastodonInstanceProvider(
         MainMastodonCoreModule.context,
         MainMastodonCoreModule.authorizer,
@@ -39,8 +40,8 @@ internal object MainMastodonCoreModule :
         AsyncImageLoader.Provider
       )
     },
-    { MainMastodonCoreModule.authenticationLock },
-    { MainMastodonCoreModule.termMuter }
+    injectionOf { MainMastodonCoreModule.authenticationLock },
+    injectionOf { MainMastodonCoreModule.termMuter }
   ) {
   private val actorProvider by lazy { SharedPreferencesActorProvider(context) }
   private val authorizer by lazy { MastodonAuthorizer(context) }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/MainFeedModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/MainFeedModule.kt
@@ -21,11 +21,12 @@ import com.jeanbarrossilva.orca.feature.feed.FeedModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal class MainFeedModule<T>(activity: T) :
   FeedModule(
-    { Injector.from<CoreModule>().instanceProvider().provide().feedProvider },
-    { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
-    { NavigatorFeedBoundary(activity, activity.navigator) },
-    onBottomAreaAvailabilityChangeListener = { activity }
+    injectionOf { Injector.from<CoreModule>().instanceProvider().provide().feedProvider },
+    injectionOf { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
+    injectionOf { NavigatorFeedBoundary(activity, activity.navigator) },
+    injectionOf { activity }
   ) where T : NavigationActivity, T : OnBottomAreaAvailabilityChangeListener

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/gallery/MainGalleryModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/gallery/MainGalleryModule.kt
@@ -20,9 +20,10 @@ import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.feature.gallery.GalleryModule
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal class MainGalleryModule(navigator: Navigator) :
   GalleryModule(
-    { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
-    { NavigatorGalleryBoundary(navigator) }
+    injectionOf { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
+    injectionOf { NavigatorGalleryBoundary(navigator) }
   )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/postdetails/MainPostDetailsModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/postdetails/MainPostDetailsModule.kt
@@ -21,10 +21,11 @@ import com.jeanbarrossilva.orca.feature.postdetails.PostDetailsModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal class MainPostDetailsModule<T>(activity: T) :
   PostDetailsModule(
-    { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
-    { NavigatorPostDetailsBoundary(activity, activity.navigator) },
-    onBottomAreaAvailabilityChangeListener = { activity }
+    injectionOf { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
+    injectionOf { NavigatorPostDetailsBoundary(activity, activity.navigator) },
+    injectionOf { activity }
   ) where T : NavigationActivity, T : OnBottomAreaAvailabilityChangeListener

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
@@ -21,11 +21,12 @@ import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal class MainProfileDetailsModule<T>(activity: T) :
   ProfileDetailsModule(
-    { Injector.from<CoreModule>().instanceProvider().provide().profileProvider },
-    { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
-    { NavigatorProfileDetailsBoundary(activity, activity.navigator) },
-    onBottomAreaAvailabilityChangeListener = { activity }
+    injectionOf { Injector.from<CoreModule>().instanceProvider().provide().profileProvider },
+    injectionOf { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
+    injectionOf { NavigatorProfileDetailsBoundary(activity, activity.navigator) },
+    injectionOf { activity }
   ) where T : NavigationActivity, T : OnBottomAreaAvailabilityChangeListener

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/search/MainSearchModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/search/MainSearchModule.kt
@@ -20,9 +20,10 @@ import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.feature.search.SearchModule
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal class MainSearchModule(navigator: Navigator) :
   SearchModule(
-    { Injector.from<CoreModule>().instanceProvider().provide().profileSearcher },
-    { NavigatorSearchBoundary(navigator) }
+    injectionOf { Injector.from<CoreModule>().instanceProvider().provide().profileSearcher },
+    injectionOf { NavigatorSearchBoundary(navigator) }
   )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/MainSettingsModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/MainSettingsModule.kt
@@ -20,9 +20,10 @@ import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.termMuter
 import com.jeanbarrossilva.orca.feature.settings.SettingsModule
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal class MainSettingsModule(private val context: Context) :
   SettingsModule(
-    { Injector.from<CoreModule>().termMuter() },
-    { ContextualSettingsBoundary(context) }
+    injectionOf { Injector.from<CoreModule>().termMuter() },
+    injectionOf { ContextualSettingsBoundary(context) }
   )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/termmuting/MainTermMutingModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/termmuting/MainTermMutingModule.kt
@@ -19,6 +19,7 @@ import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.termMuter
 import com.jeanbarrossilva.orca.feature.settings.termmuting.TermMutingModule
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal object MainTermMutingModule :
-  TermMutingModule({ Injector.from<CoreModule>().termMuter() })
+  TermMutingModule(injectionOf { Injector.from<CoreModule>().termMuter() })

--- a/core-module/src/main/java/com/jeanbarrossilva/orca/core/module/CoreModule.kt
+++ b/core-module/src/main/java/com/jeanbarrossilva/orca/core/module/CoreModule.kt
@@ -23,6 +23,7 @@ import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
 /**
  * [Module] into which core-level structures are injected.
@@ -34,7 +35,7 @@ import com.jeanbarrossilva.orca.std.injector.module.Module
  * @param termMuter [TermMuter] by which terms will be muted.
  */
 open class CoreModule(
-  @Inject internal val instanceProvider: Module.() -> InstanceProvider,
-  @Inject internal val authenticationLock: Module.() -> SomeAuthenticationLock,
-  @Inject internal val termMuter: Module.() -> TermMuter
+  @Inject internal val instanceProvider: Injection<InstanceProvider>,
+  @Inject internal val authenticationLock: Injection<SomeAuthenticationLock>,
+  @Inject internal val termMuter: Injection<TermMuter>
 ) : Module()

--- a/core/mastodon/src/androidTest/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorizationActivityTests.kt
+++ b/core/mastodon/src/androidTest/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorizationActivityTests.kt
@@ -35,6 +35,7 @@ import com.jeanbarrossilva.orca.platform.autos.test.kit.input.text.onTextFieldEr
 import com.jeanbarrossilva.orca.platform.testing.asString
 import com.jeanbarrossilva.orca.platform.testing.context
 import com.jeanbarrossilva.orca.platform.ui.core.sample
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 import com.jeanbarrossilva.orca.std.injector.test.InjectorTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -44,9 +45,9 @@ internal class MastodonAuthorizationActivityTests {
   val injectorRule = InjectorTestRule {
     register(
       CoreModule(
-        { InstanceProvider.sample },
-        { Instance.sample.authenticationLock },
-        { SampleTermMuter() }
+        injectionOf { InstanceProvider.sample },
+        injectionOf { Instance.sample.authenticationLock },
+        injectionOf { SampleTermMuter() }
       )
     )
   }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/MastodonCoreModule.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/MastodonCoreModule.kt
@@ -23,7 +23,7 @@ import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.std.injector.module.Inject
-import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
 /**
  * [CoreModule] into which Mastodon-specific core structures are injected.
@@ -35,7 +35,7 @@ import com.jeanbarrossilva.orca.std.injector.module.Module
  *   currently [authenticated][Actor.Authenticated] [Actor] is.
  */
 open class MastodonCoreModule(
-  @Inject internal val instanceProvider: Module.() -> InstanceProvider,
-  @Inject internal val authenticationLock: Module.() -> SomeAuthenticationLock,
-  @Inject internal val termMuter: Module.() -> TermMuter
+  @Inject internal val instanceProvider: Injection<InstanceProvider>,
+  @Inject internal val authenticationLock: Injection<SomeAuthenticationLock>,
+  @Inject internal val termMuter: Injection<TermMuter>
 ) : CoreModule(instanceProvider, authenticationLock, termMuter)

--- a/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/client/test/TestScope.extensions.kt
+++ b/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/client/test/TestScope.extensions.kt
@@ -29,6 +29,7 @@ import com.jeanbarrossilva.orca.core.test.TestActorProvider
 import com.jeanbarrossilva.orca.core.test.TestAuthenticator
 import com.jeanbarrossilva.orca.core.test.TestAuthorizer
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequest
 import io.ktor.http.HttpMethod
@@ -125,11 +126,10 @@ private fun <T : Actor> runCoreHttpClientTest(
   val instance = TestMastodonInstance(authorizer, authenticator, authenticationLock)
   val module =
     MastodonCoreModule(
-      { TestHttpInstanceProvider(authorizer, authenticator, authenticationLock) },
-      { authenticationLock }
-    ) {
-      SampleTermMuter()
-    }
+      injectionOf { TestHttpInstanceProvider(authorizer, authenticator, authenticationLock) },
+      injectionOf { authenticationLock },
+      injectionOf { SampleTermMuter() }
+    )
   Injector.register<CoreModule>(module)
   runTest { CoreHttpClientTestScope(delegate = this, instance.client, actor).body() }
   Injector.unregister<CoreModule>()

--- a/ext/coroutines/build.gradle.kts
+++ b/ext/coroutines/build.gradle.kts
@@ -22,9 +22,9 @@ plugins {
 dependencies {
   api(libs.kotlin.coroutines.core)
 
+  testImplementation(project(":ext:reflection"))
   testImplementation(libs.assertk)
   testImplementation(libs.kotlin.coroutines.test)
-  testImplementation(libs.kotlin.reflect)
   testImplementation(libs.kotlin.test)
   testImplementation(libs.turbine)
 }

--- a/ext/coroutines/src/test/java/com/jeanbarrossilva/orca/ext/coroutines/notifier/NotifierTests.kt
+++ b/ext/coroutines/src/test/java/com/jeanbarrossilva/orca/ext/coroutines/notifier/NotifierTests.kt
@@ -18,6 +18,7 @@ package com.jeanbarrossilva.orca.ext.coroutines.notifier
 import assertk.assertThat
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isSameAs
+import com.jeanbarrossilva.orca.ext.reflection.access
 import kotlin.test.Test
 
 internal class NotifierTests {

--- a/ext/reflection/build.gradle.kts
+++ b/ext/reflection/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,16 +13,15 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.std.injector
+plugins {
+  alias(libs.plugins.kotlin.jvm)
 
-/**
- * Casts this to [T].
- *
- * @param T Value to which this will be casted.
- * @throws ClassCastException If this cannot be casted to [T].
- */
-@PublishedApi
-@Throws(ClassCastException::class)
-internal fun <T> Any.castTo(): T {
-  @Suppress("UNCHECKED_CAST") return this as T
+  `java-library`
+}
+
+dependencies {
+  api(libs.kotlin.reflect)
+
+  testImplementation(libs.assertk)
+  testImplementation(libs.kotlin.test)
 }

--- a/ext/reflection/src/main/java/com/jeanbarrossilva/orca/ext/reflection/KCallable.extensions.kt
+++ b/ext/reflection/src/main/java/com/jeanbarrossilva/orca/ext/reflection/KCallable.extensions.kt
@@ -13,7 +13,7 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.ext.coroutines.notifier
+package com.jeanbarrossilva.orca.ext.reflection
 
 import kotlin.reflect.KCallable
 import kotlin.reflect.jvm.isAccessible
@@ -27,7 +27,7 @@ import kotlin.reflect.jvm.isAccessible
  * @param access Access to be performed while this [KCallable] is ensured to be accessible.
  * @see KCallable.isAccessible
  */
-internal fun <I : KCallable<*>, O> I.access(access: I.() -> O): O {
+fun <I : KCallable<*>, O> I.access(access: I.() -> O): O {
   val wasAccessible = isAccessible
   isAccessible = true
   return access().also { isAccessible = wasAccessible }

--- a/ext/reflection/src/test/java/com/jeanbarrossilva/orca/ext/reflection/KCallableExtensionsTests.kt
+++ b/ext/reflection/src/test/java/com/jeanbarrossilva/orca/ext/reflection/KCallableExtensionsTests.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.ext.reflection
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.jvm.isAccessible
+import kotlin.test.Test
+
+internal class KCallableExtensionsTests {
+  @Test
+  fun accesses() {
+    assertThat(
+        object {
+            @Suppress("unused") private var msg = "🏛️📚👩🏻‍💻"
+          }::class
+          .declaredMemberProperties
+          .filterIsInstance<KMutableProperty1<Any, String>>()
+          .single()
+          .access { isAccessible }
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun changesAccessibilityToPreviousOneAfterAccessing() {
+    assertThat(
+        object {
+            @Suppress("unused") private val msg = "⌛️"
+          }::class
+          .declaredMemberProperties
+          .single()
+          .access { this }
+          .isAccessible
+      )
+      .isFalse()
+  }
+}

--- a/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/TestFeedModule.kt
+++ b/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/TestFeedModule.kt
@@ -19,11 +19,12 @@ import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.feature.feed.FeedModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.platform.ui.core.sample
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal object TestFeedModule :
   FeedModule(
-    { Instance.sample.feedProvider },
-    { Instance.sample.postProvider },
-    { TestFeedBoundary() },
-    { OnBottomAreaAvailabilityChangeListener.empty }
+    injectionOf { Instance.sample.feedProvider },
+    injectionOf { Instance.sample.postProvider },
+    injectionOf { TestFeedBoundary() },
+    injectionOf { OnBottomAreaAvailabilityChangeListener.empty }
   )

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedModule.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedModule.kt
@@ -20,12 +20,13 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
 open class FeedModule(
-  @Inject internal val feedProvider: Module.() -> FeedProvider,
-  @Inject internal val postProvider: Module.() -> PostProvider,
-  @Inject internal val boundary: Module.() -> FeedBoundary,
+  @Inject internal val feedProvider: Injection<FeedProvider>,
+  @Inject internal val postProvider: Injection<PostProvider>,
+  @Inject internal val boundary: Injection<FeedBoundary>,
   @Inject
   internal val onBottomAreaAvailabilityChangeListener:
-    Module.() -> OnBottomAreaAvailabilityChangeListener
+    Injection<OnBottomAreaAvailabilityChangeListener>
 ) : Module()

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/activity/TestGalleryModule.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/activity/TestGalleryModule.kt
@@ -18,6 +18,7 @@ package com.jeanbarrossilva.orca.feature.gallery.test.activity
 import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.feature.gallery.GalleryModule
 import com.jeanbarrossilva.orca.platform.ui.core.sample
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal object TestGalleryModule :
-  GalleryModule({ Instance.sample.postProvider }, { TestGalleryBoundary })
+  GalleryModule(injectionOf { Instance.sample.postProvider }, injectionOf { TestGalleryBoundary })

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryModule.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryModule.kt
@@ -18,8 +18,9 @@ package com.jeanbarrossilva.orca.feature.gallery
 import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
 open class GalleryModule(
-  @Inject val postProvider: Module.() -> PostProvider,
-  @Inject val boundary: Module.() -> GalleryBoundary
+  @Inject val postProvider: Injection<PostProvider>,
+  @Inject val boundary: Injection<GalleryBoundary>
 ) : Module()

--- a/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetailsModule.kt
+++ b/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetailsModule.kt
@@ -19,11 +19,12 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
 abstract class PostDetailsModule(
-  @Inject internal val postProvider: Module.() -> PostProvider,
-  @Inject internal val boundary: Module.() -> PostDetailsBoundary,
+  @Inject internal val postProvider: Injection<PostProvider>,
+  @Inject internal val boundary: Injection<PostDetailsBoundary>,
   @Inject
   internal val onBottomAreaAvailabilityChangeListener:
-    Module.() -> OnBottomAreaAvailabilityChangeListener
+    Injection<OnBottomAreaAvailabilityChangeListener>
 ) : Module()

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/TestProfileDetailsModule.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/TestProfileDetailsModule.kt
@@ -19,11 +19,12 @@ import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.platform.ui.core.sample
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 internal object TestProfileDetailsModule :
   ProfileDetailsModule(
-    { Instance.sample.profileProvider },
-    { Instance.sample.postProvider },
-    { TestProfileDetailsBoundary() },
-    { OnBottomAreaAvailabilityChangeListener.empty }
+    injectionOf { Instance.sample.profileProvider },
+    injectionOf { Instance.sample.postProvider },
+    injectionOf { TestProfileDetailsBoundary() },
+    injectionOf { OnBottomAreaAvailabilityChangeListener.empty }
   )

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsModule.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsModule.kt
@@ -20,12 +20,13 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
 abstract class ProfileDetailsModule(
-  @Inject internal val profileProvider: Module.() -> ProfileProvider,
-  @Inject internal val postProvider: Module.() -> PostProvider,
-  @Inject internal val boundary: Module.() -> ProfileDetailsBoundary,
+  @Inject internal val profileProvider: Injection<ProfileProvider>,
+  @Inject internal val postProvider: Injection<PostProvider>,
+  @Inject internal val boundary: Injection<ProfileDetailsBoundary>,
   @Inject
   internal val onBottomAreaAvailabilityChangeListener:
-    Module.() -> OnBottomAreaAvailabilityChangeListener
+    Injection<OnBottomAreaAvailabilityChangeListener>
 ) : Module()

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchModule.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchModule.kt
@@ -18,8 +18,9 @@ package com.jeanbarrossilva.orca.feature.search
 import com.jeanbarrossilva.orca.core.feed.profile.search.ProfileSearcher
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
 abstract class SearchModule(
-  @Inject internal val searcher: Module.() -> ProfileSearcher,
-  @Inject internal val boundary: Module.() -> SearchBoundary
+  @Inject internal val searcher: Injection<ProfileSearcher>,
+  @Inject internal val boundary: Injection<SearchBoundary>
 ) : Module()

--- a/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsModule.kt
+++ b/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsModule.kt
@@ -18,8 +18,9 @@ package com.jeanbarrossilva.orca.feature.settings
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.TermMuter
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
 abstract class SettingsModule(
-  @Inject internal val termMuter: Module.() -> TermMuter,
-  @Inject internal val boundary: Module.() -> SettingsBoundary
+  @Inject internal val termMuter: Injection<TermMuter>,
+  @Inject internal val boundary: Injection<SettingsBoundary>
 ) : Module()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,7 @@ include(
   ":core-test",
   ":ext:coroutines",
   ":ext:processing",
+  ":ext:reflection",
   ":ext:testing",
   ":feature:composer",
   ":feature:feed",

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSPropertyDeclaration.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSPropertyDeclaration.extensions.kt
@@ -16,16 +16,9 @@
 package com.jeanbarrossilva.orca.std.injector.processor.inject
 
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import com.google.devtools.ksp.symbol.KSTypeArgument
-import com.jeanbarrossilva.orca.std.injector.module.Module
-import com.squareup.kotlinpoet.ksp.toTypeName
-import com.squareup.kotlinpoet.typeNameOf
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
+import com.squareup.kotlinpoet.ksp.toClassName
 
 /** Whether this [KSPropertyDeclaration]'s return type is considered to be an injection. */
 internal val KSPropertyDeclaration.isInjection
-  get() =
-    with(type.resolve().arguments.map(KSTypeArgument::toTypeName)) {
-      firstOrNull() == typeNameOf<Module>() &&
-        !last().isNullable &&
-        last().toString() != "kotlin.Nothing"
-    }
+  get() = type.resolve().toClassName().canonicalName == Injection::class.qualifiedName

--- a/std/injector-processor/src/test/java/com/jeanbarrossilva/orca/std/injector/processor/inject/InjectProcessorTests.kt
+++ b/std/injector-processor/src/test/java/com/jeanbarrossilva/orca/std/injector/processor/inject/InjectProcessorTests.kt
@@ -33,11 +33,12 @@ internal class InjectProcessorTests {
         """
             import com.jeanbarrossilva.orca.std.injector.module.Inject
             import com.jeanbarrossilva.orca.std.injector.module.Module
+            import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
-            class SubModule(@Inject override val dependency: Module.() -> Int = { 0 }) :
+            class SubModule(@Inject override val dependency: Injection<Int> = { 0 }) :
               SuperModule(dependency)
 
-            abstract class SuperModule(@Inject open val dependency: Module.() -> Int = { 0 }) :
+            abstract class SuperModule(@Inject open val dependency: Injection<Int> = { 0 }) :
               Module()
         """
           .trimIndent()

--- a/std/injector-test/src/main/java/com/jeanbarrossilva/orca/std/injector/test/InjectorTestRule.kt
+++ b/std/injector-test/src/main/java/com/jeanbarrossilva/orca/std/injector/test/InjectorTestRule.kt
@@ -19,13 +19,13 @@ import com.jeanbarrossilva.orca.std.injector.Injector
 import org.junit.rules.ExternalResource
 
 /**
- * Rule for running the [injection] before and clearing the [Injector] after the test is done.
+ * Rule for running the [action] before and clearing the [Injector] after the test is done.
  *
- * @param injection Operation to be performed on the [Injector].
+ * @param action Operation to be performed on the [Injector].
  */
-class InjectorTestRule(private val injection: Injector.() -> Unit = {}) : ExternalResource() {
+class InjectorTestRule(private val action: Injector.() -> Unit = {}) : ExternalResource() {
   override fun before() {
-    Injector.injection()
+    Injector.action()
   }
 
   override fun after() {

--- a/std/injector/build.gradle.kts
+++ b/std/injector/build.gradle.kts
@@ -21,7 +21,9 @@ plugins {
 }
 
 dependencies {
-  implementation(libs.kotlin.reflect)
+  implementation(project(":ext:reflection"))
+
+  kspTest(project(":std:injector-processor"))
 
   testImplementation(project(":std:injector-test"))
   testImplementation(libs.assertk)

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt
@@ -15,13 +15,13 @@
 
 package com.jeanbarrossilva.orca.std.injector
 
+import com.jeanbarrossilva.orca.ext.reflection.access
 import com.jeanbarrossilva.orca.std.injector.module.Module
 import com.jeanbarrossilva.orca.std.injector.module.binding.Binding
 import com.jeanbarrossilva.orca.std.injector.module.binding.SomeBinding
 import com.jeanbarrossilva.orca.std.injector.module.binding.boundTo
 import kotlin.reflect.KClass
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.isAccessible
 
 /** [Module] that enables global [Module] and dependency injection. */
 object Injector : Module() {
@@ -135,12 +135,7 @@ object Injector : Module() {
     T::class
       .memberProperties
       .filterIsInjection()
-      .associateBy { it.returnType.arguments.last().type?.classifier }
-      .mapKeys { (dependencyClassifier, _) -> dependencyClassifier as KClass<*> }
-      .onEach { (_, property) -> property.isAccessible = true }
-      .mapValues { (_, property) -> property.get(module) }
-      .forEach { (dependencyClass, injection) ->
-        module.inject(dependencyClass, injection.castTo())
-      }
+      .map { it.access { get(module) } }
+      .forEach(module::inject)
   }
 }

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Iterable.extensions.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Iterable.extensions.kt
@@ -17,28 +17,26 @@ package com.jeanbarrossilva.orca.std.injector
 
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.hasAnnotation
-import kotlin.reflect.typeOf
+import kotlin.reflect.jvm.jvmErasure
 
 /**
  * Returns a [List] containing only [KProperty1]s that characterize an injection into a [Module].
- * Those:
- * - Are annotated with [Inject], denoting that the dependencies returned by their values should be
- *   automatically injected into the [Module] in which they were declared;
- * - Have a return type of `Module.() -> Any`, which allows for operations to be performed within
- *   the [Module] and returns a dependency of any non-`null` type.
+ * Those...
+ * - are annotated with [Inject], denoting that the dependencies provided by their values should be
+ *   automatically injected into the [Module] in which they were declared; and
+ * - have a return type of [Injection], which allows for operations to be performed within the
+ *   [Module] and provides a dependency lazily.
  *
  * @param T [Module] into which the resulting dependencies of the [KProperty1]s' values will be
  *   injected.
  */
 @PublishedApi
-internal fun <T : Module> Collection<KProperty1<T, *>>.filterIsInjection():
-  List<KProperty1<T, Module.() -> Any>> {
-  return filter {
-      it.hasAnnotation<Inject>() &&
-        it.returnType.arguments.size == 2 &&
-        it.returnType.arguments.first().type == typeOf<Module>()
-    }
-    .castTo()
+internal fun <T : Module> Iterable<KProperty1<T, *>>.filterIsInjection():
+  List<KProperty1<T, Injection<Any>>> {
+  @Suppress("UNCHECKED_CAST")
+  return filter { it.hasAnnotation<Inject>() && it.returnType.jvmErasure == Injection::class }
+    as List<KProperty1<T, Injection<Any>>>
 }

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/Inject.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/Inject.kt
@@ -16,19 +16,23 @@
 package com.jeanbarrossilva.orca.std.injector.module
 
 import com.jeanbarrossilva.orca.std.injector.Injector
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 
 /**
- * Denotes that the dependency returned by the value of the annotated property should be
+ * Denotes that the dependency provided by the value of the annotated property should be
  * automatically injected into the [Module] in which it was declared and that an extension function
  * for getting its result should be created for that same [Module].
  *
- * For example, declaring `class MyModule(@Inject val dependency: Module.() -> Int)` and registering
+ * For example, declaring `class MyModule(@Inject val dependency: Injection<Int>)` and registering
  * it in the [Injector] injects `dependency` into `MyModule` and makes its provided `Int` accessible
  * via a `MyModule.dependency()` extension function.
  *
- * Note that the annotated property should return a `Module.() -> Any`, which is how an injection is
- * recognized; otherwise, an error will be thrown at build time.
+ * Note that the annotated property should return an [Injection]; otherwise, an error will be thrown
+ * at build time.
  *
+ * @see Module.inject
  * @see Injector.register
+ * @see injectionOf
  */
 @Target(AnnotationTarget.PROPERTY) annotation class Inject

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/injection/Injection.extensions.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/injection/Injection.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,11 +13,22 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.settings.termmuting
+package com.jeanbarrossilva.orca.std.injector.module.injection
 
-import com.jeanbarrossilva.orca.core.feed.profile.post.content.TermMuter
-import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
-import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
 
-abstract class TermMutingModule(@Inject internal val termMuter: Injection<TermMuter>) : Module()
+/**
+ * Creates an [Injection].
+ *
+ * @param T Dependency to be injected.
+ * @param creation Returns the dependency to be injected that can be lazily retrieved afterwards.
+ */
+inline fun <reified T : Any> injectionOf(crossinline creation: Module.() -> T): Injection<T> {
+  return object : Injection<T>() {
+    override val dependencyClass = T::class
+
+    override fun Module.create(): T {
+      return creation()
+    }
+  }
+}

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/injection/Injection.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/injection/Injection.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.std.injector.module.injection
+
+import com.jeanbarrossilva.orca.std.injector.module.Module
+import kotlin.reflect.KClass
+
+/**
+ * Lazily provides the dependency to be injected into a given [Module].
+ *
+ * @param T Dependency to be injected.
+ * @see injectionOf
+ * @see provide
+ */
+abstract class Injection<T : Any> @PublishedApi internal constructor() {
+  /** Dependency to be injected. */
+  private var dependency: T? = null
+
+  /** [KClass] of the [dependency]. */
+  @PublishedApi internal abstract val dependencyClass: KClass<T>
+
+  /**
+   * Retrieves the dependency to be injected or creates it if it's the first time that it's being
+   * requested to be provided.
+   *
+   * @see create
+   */
+  fun Module.provide(): T {
+    return dependency ?: create().also { dependency = it }
+  }
+
+  /** Creates the dependency to be injected. */
+  protected abstract fun Module.create(): T
+}

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/injection/Iterable.extensions.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/injection/Iterable.extensions.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.std.injector.module.injection
+
+/**
+ * Whether this [Iterable] contains an [Injection] whose dependency's type is [T].
+ *
+ * @param T Dependency to look for.
+ */
+@PublishedApi
+internal inline fun <reified T : Any> Iterable<Injection<*>>.contains(): Boolean {
+  return any { it.dependencyClass == T::class }
+}
+
+/**
+ * Obtains the [Injection] whose dependency's type is [T].
+ *
+ * @param T Dependency of the [Injection] to be obtained.
+ */
+@PublishedApi
+internal inline fun <reified T : Any> Iterable<Injection<*>>.get(): Injection<T>? {
+  @Suppress("UNCHECKED_CAST") return find { it.dependencyClass == T::class } as Injection<T>?
+}

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/InjectorTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/InjectorTests.kt
@@ -20,6 +20,8 @@ import assertk.assertions.isEqualTo
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 import com.jeanbarrossilva.orca.std.injector.module.binding.boundTo
+import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
+import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 import com.jeanbarrossilva.orca.std.injector.test.InjectorTestRule
 import kotlin.test.Test
 import org.junit.Rule
@@ -28,16 +30,18 @@ internal class InjectorTests {
   @get:Rule val injectorRule = InjectorTestRule()
 
   private abstract class SuperModuleWithNonAnnotatedDependency(
-    @Suppress("unused") private val dependency: Module.() -> Int
+    @Suppress("unused") private val dependency: Injection<Int>
   ) : Module()
 
-  private class SubModuleWithAnnotatedDependency : SuperModuleWithAnnotatedDependency({ 0 })
+  private class SubModuleWithAnnotatedDependency :
+    SuperModuleWithAnnotatedDependency(injectionOf { 0 })
 
   internal abstract class SuperModuleWithAnnotatedDependency(
-    @Suppress("unused") @Inject val dependency: Module.() -> Int
+    @Suppress("unused") @Inject val dependency: Injection<Int>
   ) : Module()
 
-  private class SubModuleWithNonAnnotatedDependency : SuperModuleWithNonAnnotatedDependency({ 0 })
+  private class SubModuleWithNonAnnotatedDependency :
+    SuperModuleWithNonAnnotatedDependency(injectionOf { 0 })
 
   @Test(expected = Injector.SelfRegistrationException::class)
   fun throwsWhenRegisteringItself() {

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/module/ModuleTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/module/ModuleTests.kt
@@ -13,11 +13,11 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.std.injector
+package com.jeanbarrossilva.orca.std.injector.module
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.jeanbarrossilva.orca.std.injector.module.Module
+import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.injector.test.InjectorTestRule
 import kotlin.test.Test
 import org.junit.Rule

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/module/binding/BindingExtensionsTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/module/binding/BindingExtensionsTests.kt
@@ -13,11 +13,22 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.settings.termmuting
+package com.jeanbarrossilva.orca.std.injector.module.binding
 
-import com.jeanbarrossilva.orca.core.feed.profile.post.content.TermMuter
-import com.jeanbarrossilva.orca.std.injector.module.Inject
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import com.jeanbarrossilva.orca.std.injector.module.Module
-import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
+import kotlin.test.Test
 
-abstract class TermMutingModule(@Inject internal val termMuter: Injection<TermMuter>) : Module()
+internal class BindingExtensionsTests {
+  class SubModule : SuperModule()
+
+  abstract class SuperModule : Module()
+
+  @Test
+  fun binds() {
+    val module = SubModule()
+    assertThat(module.boundTo<SuperModule, SubModule>())
+      .isEqualTo(Binding(SuperModule::class, SubModule::class, module))
+  }
+}

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/module/injection/InjectionExtensionsTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/module/injection/InjectionExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,24 +13,33 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.std.injector.binding
+package com.jeanbarrossilva.orca.std.injector.module.injection
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
+import assertk.assertions.isSameAs
+import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.injector.module.Module
-import com.jeanbarrossilva.orca.std.injector.module.binding.Binding
-import com.jeanbarrossilva.orca.std.injector.module.binding.boundTo
 import kotlin.test.Test
 
-internal class BindingExtensionsTests {
-  class SubModule : SuperModule()
-
-  abstract class SuperModule : Module()
-
+internal class InjectionExtensionsTests {
   @Test
-  fun binds() {
-    val module = SubModule()
-    assertThat(module.boundTo<SuperModule, SubModule>())
-      .isEqualTo(Binding(SuperModule::class, SubModule::class, module))
+  fun createsInjection() {
+    val dependency = Object()
+    with(Injector) {
+      assertThat(with(injectionOf { dependency }) { provide() })
+        .isSameAs(
+          with(
+            object : Injection<Any>() {
+              override val dependencyClass = Any::class
+
+              override fun Module.create(): Any {
+                return dependency
+              }
+            }
+          ) {
+            provide()
+          }
+        )
+    }
   }
 }

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/module/injection/InjectionTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/module/injection/InjectionTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,11 +13,20 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.settings.termmuting
+package com.jeanbarrossilva.orca.std.injector.module.injection
 
-import com.jeanbarrossilva.orca.core.feed.profile.post.content.TermMuter
-import com.jeanbarrossilva.orca.std.injector.module.Inject
-import com.jeanbarrossilva.orca.std.injector.module.Module
-import com.jeanbarrossilva.orca.std.injector.module.injection.Injection
+import assertk.assertThat
+import assertk.assertions.isSameAs
+import com.jeanbarrossilva.orca.std.injector.Injector
+import kotlin.test.Test
 
-abstract class TermMutingModule(@Inject internal val termMuter: Injection<TermMuter>) : Module()
+internal class InjectionTests {
+  @Test
+  fun retrievesCreatedDependencyWhenProvidedSubsequently() {
+    val injection = injectionOf { Object() }
+    val provide = { with(Injector) { with(injection) { provide() } } }
+    val created = provide()
+    val retrieved = provide()
+    assertThat(retrieved).isSameAs(created)
+  }
+}


### PR DESCRIPTION
Turns what was known to [`:std:injector`](https://github.com/the-orca-app/android/tree/4dd3687a788965ee08e9d96996b1b80ec948155a/std/injector) to be an injection into a specific type, [`Injection`](https://github.com/the-orca-app/android/blob/4dd3687a788965ee08e9d96996b1b80ec948155a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/injection/Injection.kt), instead of a `Module.() -> Any` lambda.