### PR TITLE
Move navigation structures from `:platform:ui` to `:platform:navigation`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ android {
 dependencies {
   "androidTestDemoImplementation"(project(":core:sample-test"))
   "androidTestDemoImplementation"(project(":feature:gallery-test"))
+  "androidTestDemoImplementation"(project(":platform:navigation-test"))
   "androidTestDemoImplementation"(project(":platform:ui"))
   "androidTestDemoImplementation"(libs.android.activity.ktx)
   "androidTestDemoImplementation"(libs.android.compose.ui.test.junit)
@@ -98,6 +99,7 @@ dependencies {
   implementation(project(":feature:settings"))
   implementation(project(":feature:settings:term-muting"))
   implementation(project(":platform:autos"))
+  implementation(project(":platform:navigation"))
   implementation(project(":platform:ui"))
   implementation(project(":std:injector"))
   implementation(libs.android.appcompat)

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/FeedTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/FeedTests.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
+import assertk.assertThat
 import com.jeanbarrossilva.orca.app.demo.test.onSearchAction
 import com.jeanbarrossilva.orca.app.demo.test.performScrollToPostPreviewWithGalleryPreview
 import com.jeanbarrossilva.orca.app.demo.test.performScrollToPostPreviewWithLinkCard
@@ -35,7 +36,7 @@ import com.jeanbarrossilva.orca.feature.feed.FeedFragment
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
 import com.jeanbarrossilva.orca.feature.gallery.test.ui.onCloseActionButton
 import com.jeanbarrossilva.orca.feature.search.SearchActivity
-import com.jeanbarrossilva.orca.platform.ui.test.assertIsAtFragment
+import com.jeanbarrossilva.orca.platform.navigation.test.isAt
 import com.jeanbarrossilva.orca.platform.ui.test.component.timeline.onRefreshIndicator
 import com.jeanbarrossilva.orca.platform.ui.test.component.timeline.onTimeline
 import com.jeanbarrossilva.orca.platform.ui.test.component.timeline.post.figure.gallery.thumbnail.onThumbnails
@@ -83,7 +84,7 @@ internal class FeedTests {
       onTimeline().performScrollToPostPreviewWithGalleryPreview {
         onThumbnails().onFirst().performClick()
         onCloseActionButton().performClick()
-        assertIsAtFragment(composeRule.activity, FeedFragment.ROUTE)
+        assertThat(composeRule.activity).isAt(FeedFragment.ROUTE)
       }
     }
   }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/ProfileDetailsTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/ProfileDetailsTests.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import assertk.assertThat
 import com.jeanbarrossilva.orca.app.R
 import com.jeanbarrossilva.orca.app.demo.test.performScrollToPostPreviewWithLinkCard
 import com.jeanbarrossilva.orca.app.demo.test.performStartClick
@@ -30,7 +31,7 @@ import com.jeanbarrossilva.orca.core.sample.test.feed.profile.post.content.highl
 import com.jeanbarrossilva.orca.core.sample.test.feed.profile.post.withSamples
 import com.jeanbarrossilva.orca.ext.intents.intendBrowsingTo
 import com.jeanbarrossilva.orca.feature.postdetails.PostDetailsFragment
-import com.jeanbarrossilva.orca.platform.ui.test.assertIsAtFragment
+import com.jeanbarrossilva.orca.platform.navigation.test.isAt
 import com.jeanbarrossilva.orca.platform.ui.test.component.timeline.post.figure.link.onLinkCards
 import com.jeanbarrossilva.orca.platform.ui.test.component.timeline.post.onPostPreviews
 import org.junit.Rule
@@ -51,9 +52,7 @@ internal class ProfileDetailsTests {
   fun navigatesToPostDetailsOnPostPreviewClick() {
     onView(withId(R.id.profile_details)).perform(click())
     composeRule.onPostPreviews().onFirst().performStartClick()
-    assertIsAtFragment(
-      composeRule.activity,
-      PostDetailsFragment.getRoute(Posts.withSamples.first().id)
-    )
+    assertThat(composeRule.activity)
+      .isAt(PostDetailsFragment.getRoute(Posts.withSamples.first().id))
   }
 }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/activity/OrcaActivity.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/activity/OrcaActivity.kt
@@ -24,7 +24,7 @@ import com.jeanbarrossilva.orca.app.activity.delegate.Injection
 import com.jeanbarrossilva.orca.app.databinding.ActivityOrcaBinding
 import com.jeanbarrossilva.orca.app.module.core.MainMastodonCoreModule
 import com.jeanbarrossilva.orca.core.module.CoreModule
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
+import com.jeanbarrossilva.orca.platform.navigation.NavigationActivity
 
 open class OrcaActivity :
   NavigationActivity(), BottomNavigationViewAvailability, Injection, BottomNavigation {

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/activity/delegate/BottomNavigation.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/activity/delegate/BottomNavigation.kt
@@ -19,7 +19,7 @@ import androidx.annotation.IdRes
 import androidx.lifecycle.lifecycleScope
 import com.jeanbarrossilva.orca.app.R
 import com.jeanbarrossilva.orca.app.navigation.BottomDestinationProvider
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
+import com.jeanbarrossilva.orca.platform.navigation.NavigationActivity
 import kotlinx.coroutines.launch
 
 internal interface BottomNavigation : Binding {

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/activity/delegate/Injection.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/activity/delegate/Injection.kt
@@ -35,7 +35,7 @@ import com.jeanbarrossilva.orca.feature.search.SearchModule
 import com.jeanbarrossilva.orca.feature.settings.SettingsModule
 import com.jeanbarrossilva.orca.feature.settings.termmuting.TermMutingModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
+import com.jeanbarrossilva.orca.platform.navigation.NavigationActivity
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 internal interface Injection {

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/MainFeedModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/MainFeedModule.kt
@@ -19,7 +19,7 @@ import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.feature.feed.FeedModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
+import com.jeanbarrossilva.orca.platform.navigation.NavigationActivity
 import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/NavigatorFeedBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/NavigatorFeedBoundary.kt
@@ -24,8 +24,8 @@ import com.jeanbarrossilva.orca.feature.feed.FeedBoundary
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
 import com.jeanbarrossilva.orca.feature.postdetails.PostDetailsFragment
 import com.jeanbarrossilva.orca.feature.search.SearchActivity
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
 import com.jeanbarrossilva.orca.platform.ui.core.browseTo
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import java.net.URL
 
 internal class NavigatorFeedBoundary(

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/gallery/MainGalleryModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/gallery/MainGalleryModule.kt
@@ -18,7 +18,7 @@ package com.jeanbarrossilva.orca.app.module.feature.gallery
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.feature.gallery.GalleryModule
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
 import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/gallery/NavigatorGalleryBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/gallery/NavigatorGalleryBoundary.kt
@@ -17,7 +17,7 @@ package com.jeanbarrossilva.orca.app.module.feature.gallery
 
 import com.jeanbarrossilva.orca.feature.gallery.GalleryBoundary
 import com.jeanbarrossilva.orca.feature.postdetails.PostDetailsFragment
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
 
 internal class NavigatorGalleryBoundary(private val navigator: Navigator) : GalleryBoundary {
   override fun navigateToPostDetails(id: String) {

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/postdetails/MainPostDetailsModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/postdetails/MainPostDetailsModule.kt
@@ -19,7 +19,7 @@ import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.feature.postdetails.PostDetailsModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
+import com.jeanbarrossilva.orca.platform.navigation.NavigationActivity
 import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/postdetails/NavigatorPostDetailsBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/postdetails/NavigatorPostDetailsBoundary.kt
@@ -22,8 +22,8 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
 import com.jeanbarrossilva.orca.feature.postdetails.PostDetailsBoundary
 import com.jeanbarrossilva.orca.feature.postdetails.PostDetailsFragment
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
 import com.jeanbarrossilva.orca.platform.ui.core.browseTo
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import java.net.URL
 
 internal class NavigatorPostDetailsBoundary(

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
@@ -19,7 +19,7 @@ import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsModule
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.NavigationActivity
+import com.jeanbarrossilva.orca.platform.navigation.NavigationActivity
 import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/NavigatorProfileDetailsBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/NavigatorProfileDetailsBoundary.kt
@@ -22,8 +22,8 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
 import com.jeanbarrossilva.orca.feature.postdetails.PostDetailsFragment
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsBoundary
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
 import com.jeanbarrossilva.orca.platform.ui.core.browseTo
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import java.net.URL
 
 internal class NavigatorProfileDetailsBoundary(

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/search/MainSearchModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/search/MainSearchModule.kt
@@ -18,7 +18,7 @@ package com.jeanbarrossilva.orca.app.module.feature.search
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.feature.search.SearchModule
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
 import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.injector.module.injection.injectionOf
 

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/navigation/BottomDestinationProvider.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/navigation/BottomDestinationProvider.kt
@@ -23,9 +23,9 @@ import com.jeanbarrossilva.orca.feature.feed.FeedFragment
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsFragment
 import com.jeanbarrossilva.orca.feature.profiledetails.navigation.BackwardsNavigationState
 import com.jeanbarrossilva.orca.feature.settings.SettingsFragment
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication.disallowingDuplication
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.suddenly
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
+import com.jeanbarrossilva.orca.platform.navigation.duplication.disallowingDuplication
+import com.jeanbarrossilva.orca.platform.navigation.transition.suddenly
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 internal enum class BottomDestinationProvider {

--- a/feature/post-details/build.gradle.kts
+++ b/feature/post-details/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
   implementation(project(":core:sample"))
   implementation(project(":ext:coroutines"))
   implementation(project(":platform:autos"))
+  implementation(project(":platform:navigation"))
   implementation(project(":platform:ui"))
   implementation(project(":std:injector"))
   implementation(libs.android.lifecycle.viewmodel)

--- a/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetailsFragment.kt
+++ b/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetailsFragment.kt
@@ -19,10 +19,10 @@ import androidx.compose.runtime.Composable
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import com.jeanbarrossilva.orca.feature.postdetails.viewmodel.PostDetailsViewModel
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
+import com.jeanbarrossilva.orca.platform.navigation.transition.opening
 import com.jeanbarrossilva.orca.platform.ui.core.argument
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableFragment
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.opening
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 class PostDetailsFragment private constructor() : ComposableFragment() {

--- a/feature/profile-details/build.gradle.kts
+++ b/feature/profile-details/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   implementation(project(":core:sample"))
   implementation(project(":ext:coroutines"))
   implementation(project(":platform:autos"))
+  implementation(project(":platform:navigation"))
   implementation(project(":platform:ui"))
   implementation(project(":std:injector"))
   implementation(libs.android.lifecycle.viewmodel)

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsFragment.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsFragment.kt
@@ -21,11 +21,11 @@ import androidx.compose.runtime.remember
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import com.jeanbarrossilva.orca.feature.profiledetails.navigation.BackwardsNavigationState
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
+import com.jeanbarrossilva.orca.platform.navigation.transition.opening
 import com.jeanbarrossilva.orca.platform.ui.core.argument
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableFragment
 import com.jeanbarrossilva.orca.platform.ui.core.context.ContextProvider
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.opening
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 class ProfileDetailsFragment internal constructor() : ComposableFragment(), ContextProvider {

--- a/platform/navigation-test/build.gradle.kts
+++ b/platform/navigation-test/build.gradle.kts
@@ -1,5 +1,7 @@
+import com.jeanbarrossilva.orca.namespaceFor
+
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +15,14 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation.transition
-
-import androidx.fragment.app.FragmentTransaction
-
-/** Creates a close [Transition]. */
-fun closing(): Transition {
-  return Transition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE)
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
 }
 
-/** Creates an open [Transition]. */
-fun opening(): Transition {
-  return Transition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-}
+android.namespace = namespaceFor("platform.navigation.test")
 
-/** Creates a sudden [Transition]. */
-fun suddenly(): Transition {
-  return Transition(FragmentTransaction.TRANSIT_NONE)
+dependencies {
+  implementation(libs.android.fragment.ktx)
+  implementation(libs.assertk)
 }

--- a/platform/navigation-test/src/main/AndroidManifest.xml
+++ b/platform/navigation-test/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright © 2023 Orca
+  ~ Copyright © 2024 Orca
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,10 +15,5 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application>
-        <activity
-            android:name="com.jeanbarrossilva.orca.platform.ui.core.ActivityStarterTests$TestActivity" />
-        <activity
-            android:name="com.jeanbarrossilva.orca.platform.ui.core.lifecycle.CompleteLifecycleActivity" />
-    </application>
+
 </manifest>

--- a/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/Assert.extensions.kt
+++ b/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/Assert.extensions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2023-2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.navigation.test
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import assertk.Assert
+import assertk.assertions.support.expected
+import assertk.assertions.support.show
+
+/**
+ * Asserts that the tag of the current [Fragment] within the [FragmentActivity] matches the given
+ * one.
+ *
+ * @param T [FragmentActivity] in which the [Fragment] is.
+ * @param tag Tag of the [Fragment] that's expected to be the current one.
+ */
+fun <T : FragmentActivity> Assert<T>.isAt(tag: String): Assert<T> {
+  given { it.supportFragmentManager.findFragmentByTag(tag) ?: expected("to be at:${show(tag)}") }
+  return this
+}

--- a/platform/navigation/build.gradle.kts
+++ b/platform/navigation/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,19 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.test
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+}
 
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
-import org.junit.Assert.assertNotNull
+android.defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-/**
- * Asserts that a [Fragment] tagged as [tag] is the current one within the given [activity].
- *
- * @param activity [FragmentActivity] in which the [Fragment] is supposed to be.
- * @param tag Tag of the [Fragment] that's supposed to be the current one.
- */
-fun assertIsAtFragment(activity: FragmentActivity, tag: String) {
-  assertNotNull(
-    "Fragment tagged as \"$tag\" not found.",
-    activity.supportFragmentManager.findFragmentByTag(tag)
-  )
+dependencies {
+  androidTestImplementation(project(":platform:navigation-test"))
+  androidTestImplementation(libs.android.test.core)
+  androidTestImplementation(libs.android.test.runner)
+  androidTestImplementation(libs.android.test.core)
+  androidTestImplementation(libs.assertk)
+
+  implementation(libs.android.fragment.ktx)
 }

--- a/platform/navigation/src/androidTest/AndroidManifest.xml
+++ b/platform/navigation/src/androidTest/AndroidManifest.xml
@@ -17,8 +17,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <activity
-            android:name="com.jeanbarrossilva.orca.platform.ui.core.ActivityStarterTests$TestActivity" />
+            android:name="com.jeanbarrossilva.orca.platform.navigation.NavigationActivityTests$EphemeralFragmentContainerViewActivity" />
         <activity
-            android:name="com.jeanbarrossilva.orca.platform.ui.core.lifecycle.CompleteLifecycleActivity" />
+            android:name="com.jeanbarrossilva.orca.platform.navigation.NavigationActivityTests$NoFragmentContainerViewActivity" />
+        <activity
+            android:name="com.jeanbarrossilva.orca.platform.navigation.NavigationActivityTests$UnidentifiedFragmentContainerViewActivity" />
+        <activity
+            android:name="com.jeanbarrossilva.orca.platform.navigation.NavigatorTests$TestNavigationActivity" />
     </application>
 </manifest>

--- a/platform/navigation/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/NavigationActivityTests.kt
+++ b/platform/navigation/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/NavigationActivityTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,14 +13,15 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation
+package com.jeanbarrossilva.orca.platform.navigation
 
 import android.os.Bundle
 import android.view.View
 import android.widget.FrameLayout
 import androidx.fragment.app.FragmentContainerView
 import androidx.test.core.app.launchActivity
-import org.junit.Assert.assertNotEquals
+import assertk.assertThat
+import assertk.assertions.isNotEqualTo
 import org.junit.Test
 
 internal class NavigationActivityTests {
@@ -81,7 +82,7 @@ internal class NavigationActivityTests {
     launchActivity<UnidentifiedFragmentContainerViewActivity>().use { scenario ->
       scenario.onActivity { activity ->
         activity.navigator
-        assertNotEquals(View.NO_ID, activity.view?.id)
+        assertThat(activity.view?.id).isNotEqualTo(View.NO_ID)
       }
     }
   }

--- a/platform/navigation/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/NavigatorTests.kt
+++ b/platform/navigation/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/NavigatorTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,18 +13,17 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation
+package com.jeanbarrossilva.orca.platform.navigation
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.test.core.app.launchActivity
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication.disallowingDuplication
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.closing
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.opening
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.suddenly
-import com.jeanbarrossilva.orca.platform.ui.test.assertIsAtFragment
-import org.junit.Assert.assertEquals
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jeanbarrossilva.orca.platform.navigation.test.isAt
+import com.jeanbarrossilva.orca.platform.navigation.transition.opening
+import com.jeanbarrossilva.orca.platform.navigation.transition.suddenly
 import org.junit.Test
 
 internal class NavigatorTests {
@@ -52,9 +51,9 @@ internal class NavigatorTests {
     launchActivity<TestNavigationActivity>().use { scenario ->
       scenario.onActivity { activity ->
         activity.navigator.navigate(suddenly()) {
-          to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
+          to(FirstDestinationFragment.ROUTE, NavigatorTests::FirstDestinationFragment)
         }
-        assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
+        assertThat(activity).isAt(FirstDestinationFragment.ROUTE)
       }
     }
   }
@@ -64,9 +63,9 @@ internal class NavigatorTests {
     launchActivity<TestNavigationActivity>().use { scenario ->
       scenario.onActivity { activity ->
         activity.navigator.navigate(opening()) {
-          to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
+          to(FirstDestinationFragment.ROUTE, NavigatorTests::FirstDestinationFragment)
         }
-        assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
+        assertThat(activity).isAt(FirstDestinationFragment.ROUTE)
       }
     }
   }
@@ -75,10 +74,12 @@ internal class NavigatorTests {
   fun navigatesWithClosingTransition() {
     launchActivity<TestNavigationActivity>().use { scenario ->
       scenario.onActivity { activity ->
-        activity.navigator.navigate(closing()) {
-          to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
+        activity.navigator.navigate(
+          com.jeanbarrossilva.orca.platform.navigation.transition.closing()
+        ) {
+          to(FirstDestinationFragment.ROUTE, NavigatorTests::FirstDestinationFragment)
         }
-        assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
+        assertThat(activity).isAt(FirstDestinationFragment.ROUTE)
       }
     }
   }
@@ -89,10 +90,10 @@ internal class NavigatorTests {
       scenario.onActivity { activity ->
         repeat(2) {
           activity.navigator.navigate(suddenly()) {
-            to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
+            to(FirstDestinationFragment.ROUTE, NavigatorTests::FirstDestinationFragment)
           }
         }
-        assertEquals(2, activity.supportFragmentManager.fragments.size)
+        assertThat(activity.supportFragmentManager.fragments.size).isEqualTo(2)
       }
     }
   }
@@ -102,11 +103,14 @@ internal class NavigatorTests {
     launchActivity<TestNavigationActivity>().use { scenario ->
       scenario.onActivity { activity ->
         repeat(2) {
-          activity.navigator.navigate(suddenly(), disallowingDuplication()) {
-            to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
+          activity.navigator.navigate(
+            suddenly(),
+            com.jeanbarrossilva.orca.platform.navigation.duplication.disallowingDuplication()
+          ) {
+            to(FirstDestinationFragment.ROUTE, NavigatorTests::FirstDestinationFragment)
           }
         }
-        assertEquals(1, activity.supportFragmentManager.fragments.size)
+        assertThat(activity.supportFragmentManager.fragments.size).isEqualTo(1)
       }
     }
   }
@@ -119,7 +123,7 @@ internal class NavigatorTests {
           navigate(suddenly()) { to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment) }
           navigate(suddenly()) { to(SecondDestinationFragment.ROUTE, ::SecondDestinationFragment) }
         }
-        assertIsAtFragment(activity, SecondDestinationFragment.ROUTE)
+        assertThat(activity).isAt(SecondDestinationFragment.ROUTE)
       }
     }
   }

--- a/platform/navigation/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/ViewExtensionsTests.kt
+++ b/platform/navigation/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/ViewExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,7 +13,7 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation
+package com.jeanbarrossilva.orca.platform.navigation
 
 import android.view.View
 import android.widget.FrameLayout

--- a/platform/navigation/src/main/AndroidManifest.xml
+++ b/platform/navigation/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright © 2023 Orca
+  ~ Copyright © 2024 Orca
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -14,11 +14,4 @@
   ~ not, see https://www.gnu.org/licenses.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application>
-        <activity
-            android:name="com.jeanbarrossilva.orca.platform.ui.core.ActivityStarterTests$TestActivity" />
-        <activity
-            android:name="com.jeanbarrossilva.orca.platform.ui.core.lifecycle.CompleteLifecycleActivity" />
-    </application>
-</manifest>
+<manifest />

--- a/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/NavigationActivity.kt
+++ b/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/NavigationActivity.kt
@@ -13,12 +13,12 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation
+package com.jeanbarrossilva.orca.platform.navigation
 
 import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
-import com.jeanbarrossilva.orca.platform.ui.core.content
 
 /** [FragmentActivity] through which [Navigator]-based navigation can be performed. */
 open class NavigationActivity : FragmentActivity() {
@@ -33,7 +33,8 @@ open class NavigationActivity : FragmentActivity() {
    */
   val navigator
     get() =
-      content.get<FragmentContainerView>(isInclusive = false).also(View::identify).let {
-        Navigator(supportFragmentManager, it.id)
-      }
+      requireViewById<ViewGroup>(android.R.id.content)
+        .get<FragmentContainerView>(isInclusive = false)
+        .also(View::identify)
+        .let { Navigator(supportFragmentManager, it.id) }
 }

--- a/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/Navigator.kt
+++ b/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/Navigator.kt
@@ -13,17 +13,17 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation
+package com.jeanbarrossilva.orca.platform.navigation
 
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication.Duplication
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication.allowingDuplication
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication.disallowingDuplication
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.Transition
+import com.jeanbarrossilva.orca.platform.navigation.duplication.Duplication
+import com.jeanbarrossilva.orca.platform.navigation.duplication.allowingDuplication
+import com.jeanbarrossilva.orca.platform.navigation.duplication.disallowingDuplication
+import com.jeanbarrossilva.orca.platform.navigation.transition.Transition
 
 /**
  * Navigates to [Fragment]s through [navigate].

--- a/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/View.extensions.kt
+++ b/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/View.extensions.kt
@@ -13,7 +13,7 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation
+package com.jeanbarrossilva.orca.platform.navigation
 
 import android.view.View
 import android.view.ViewGroup

--- a/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/duplication/Duplication.extensions.kt
+++ b/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/duplication/Duplication.extensions.kt
@@ -13,7 +13,7 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication
+package com.jeanbarrossilva.orca.platform.navigation.duplication
 
 /** Indicates that duplicate navigation is allowed. */
 fun allowingDuplication(): Duplication {

--- a/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/duplication/Duplication.kt
+++ b/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/duplication/Duplication.kt
@@ -13,21 +13,21 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication
+package com.jeanbarrossilva.orca.platform.navigation.duplication
 
-import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
 
 /** Indicates the approval or lack thereof of duplicate navigation. */
 sealed class Duplication {
   /** Indicates that duplicate navigation is disallowed. */
-  internal object Disallowed : Duplication() {
+  internal data object Disallowed : Duplication() {
     override fun canNavigate(previousRoute: String?, currentRoute: String): Boolean {
       return previousRoute == null || currentRoute != previousRoute
     }
   }
 
   /** Indicates that duplicate navigation is allowed. */
-  internal object Allowed : Duplication() {
+  internal data object Allowed : Duplication() {
     override fun canNavigate(previousRoute: String?, currentRoute: String): Boolean {
       return true
     }

--- a/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/transition/Transition.extensions.kt
+++ b/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/transition/Transition.extensions.kt
@@ -13,14 +13,21 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.app.module.feature.search
+package com.jeanbarrossilva.orca.platform.navigation.transition
 
-import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsFragment
-import com.jeanbarrossilva.orca.feature.search.SearchBoundary
-import com.jeanbarrossilva.orca.platform.navigation.Navigator
+import androidx.fragment.app.FragmentTransaction
 
-internal class NavigatorSearchBoundary(private val navigator: Navigator) : SearchBoundary {
-  override fun navigateToProfileDetails(id: String) {
-    ProfileDetailsFragment.navigate(navigator, id)
-  }
+/** Creates a close [Transition]. */
+fun closing(): Transition {
+  return Transition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE)
+}
+
+/** Creates an open [Transition]. */
+fun opening(): Transition {
+  return Transition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+}
+
+/** Creates a sudden [Transition]. */
+fun suddenly(): Transition {
+  return Transition(FragmentTransaction.TRANSIT_NONE)
 }

--- a/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/transition/Transition.kt
+++ b/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/transition/Transition.kt
@@ -13,7 +13,7 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core.navigation.transition
+package com.jeanbarrossilva.orca.platform.navigation.transition
 
 import androidx.fragment.app.FragmentTransaction
 

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Activity.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Activity.extensions.kt
@@ -16,12 +16,6 @@
 package com.jeanbarrossilva.orca.platform.ui.core
 
 import android.app.Activity
-import android.view.View
-import android.view.ViewGroup
-
-/** [ViewGroup] in which this [Activity]'s [View] is. */
-val Activity.content
-  get() = requireViewById<ViewGroup>(android.R.id.content)
 
 /**
  * Gets the extra put into this [Activity]'s [intent][Activity.getIntent] with the given [key]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,8 @@ include(
   ":platform:cache",
   ":platform:autos-test",
   ":platform:intents",
+  ":platform:navigation",
+  ":platform:navigation-test",
   ":platform:testing",
   ":platform:ui",
   ":platform:ui-test",


### PR DESCRIPTION
This is a step toward splitting some of [`:platform:ui`](https://github.com/the-orca-app/android/tree/ffa3b7128abc03777c0e4484d2feffc0ad052992/platform/ui)'s responsibilities to other modules. In this PR, all navigation-related (more precisely, [`Navigator`](https://github.com/the-orca-app/android/blob/ffa3b7128abc03777c0e4484d2feffc0ad052992/platform/navigation/src/main/java/com/jeanbarrossilva/orca/platform/navigation/Navigator.kt)-related) structures have been moved to [`:platform:navigation`](https://github.com/the-orca-app/android/tree/ffa3b7128abc03777c0e4484d2feffc0ad052992/platform/navigation).