### PR TITLE
Fix Time4J getting started multiple times

### DIFF
--- a/platform/ui/build.gradle.kts
+++ b/platform/ui/build.gradle.kts
@@ -21,8 +21,9 @@ plugins {
 android {
   buildFeatures.compose = true
   composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
-
-  defaultConfig { testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner" }
+  defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  packagingOptions.resources.excludes +=
+    arrayOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md")
 }
 
 dependencies {
@@ -36,6 +37,7 @@ dependencies {
   androidTestImplementation(libs.android.test.core)
   androidTestImplementation(libs.android.test.runner)
   androidTestImplementation(libs.assertk)
+  androidTestImplementation(libs.mockk)
 
   api(project(":platform:starter:lifecycle"))
   api(project(":std:image:compose"))

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/post/time/Time4JRelativeTimeProviderTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/post/time/Time4JRelativeTimeProviderTests.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.ui.component.timeline.post.time
+
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.time.ZonedDateTime
+import net.time4j.android.ApplicationStarter
+import org.junit.Test
+
+internal class Time4JRelativeTimeProviderTests {
+  @Test
+  fun startsTime4JOnce() {
+    val context: Context = InstrumentationRegistry.getInstrumentation().context
+    val provider = Time4JRelativeTimeProvider(context)
+    val zonedDateTime = ZonedDateTime.now()
+    mockkStatic(ApplicationStarter::class) {
+      repeat(2) { provider.provide(zonedDateTime) }
+      verify(exactly = 1) { ApplicationStarter.initialize(context, any<Boolean>()) }
+    }
+  }
+}

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/post/time/Time4JRelativeTimeProvider.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/post/time/Time4JRelativeTimeProvider.kt
@@ -34,7 +34,7 @@ internal class Time4JRelativeTimeProvider(private val context: Context) : Relati
   private var hasTime4JBeenStarted = false
 
   override fun onProvide(dateTime: ZonedDateTime): String {
-    startTime4JIfNotStarted()
+    startTime4JIfUnstarted()
     val locale = Locale.getDefault()
     val unixTime = dateTime.toUnixTime()
     val timeZoneID = ZoneId.systemDefault().id
@@ -42,9 +42,10 @@ internal class Time4JRelativeTimeProvider(private val context: Context) : Relati
   }
 
   /** Starts Time4J if it hasn't been started yet. */
-  private fun startTime4JIfNotStarted() {
+  private fun startTime4JIfUnstarted() {
     if (!hasTime4JBeenStarted) {
       ApplicationStarter.initialize(context, true)
+      hasTime4JBeenStarted = true
     }
   }
 


### PR DESCRIPTION
Time4J was being started each time a relative time was provided.