### PR TITLE
Fix navigation to incorrect gallery entrypoint

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,8 @@ dependencies {
   "androidTestDemoImplementation"(project(":core:sample-test"))
   "androidTestDemoImplementation"(project(":feature:gallery-test"))
   "androidTestDemoImplementation"(project(":platform:navigation-test"))
+  "androidTestDemoImplementation"(project(":platform:testing"))
+  "androidTestDemoImplementation"(project(":platform:ui-test"))
   "androidTestDemoImplementation"(libs.android.activity.ktx)
   "androidTestDemoImplementation"(libs.android.compose.ui.test.junit)
   "androidTestDemoImplementation"(libs.assertk)
@@ -110,3 +112,5 @@ dependencies {
 
   releaseImplementation(libs.kotlin.reflect)
 }
+
+kotlin.compilerOptions.freeCompilerArgs.addAll("-Xcontext-receivers")

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/FeedTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/FeedTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -23,7 +23,9 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
 import assertk.assertThat
+import com.jeanbarrossilva.orca.app.demo.test.assertContentDescriptionIsCohesiveToPagePosition
 import com.jeanbarrossilva.orca.app.demo.test.onSearchAction
+import com.jeanbarrossilva.orca.app.demo.test.perform
 import com.jeanbarrossilva.orca.app.demo.test.performScrollToPostPreviewWithGalleryPreview
 import com.jeanbarrossilva.orca.app.demo.test.performScrollToPostPreviewWithLinkCard
 import com.jeanbarrossilva.orca.composite.timeline.test.onRefreshIndicator
@@ -40,6 +42,8 @@ import com.jeanbarrossilva.orca.feature.feed.FEED_FLOATING_ACTION_BUTTON_TAG
 import com.jeanbarrossilva.orca.feature.feed.FeedFragment
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
 import com.jeanbarrossilva.orca.feature.gallery.test.ui.onCloseActionButton
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.onPager
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.performScrollToEachPage
 import com.jeanbarrossilva.orca.feature.search.SearchActivity
 import com.jeanbarrossilva.orca.platform.navigation.test.isAt
 import org.junit.Rule
@@ -73,6 +77,21 @@ internal class FeedTests {
       with(composeRule) {
         onTimeline().performScrollToPostPreviewWithGalleryPreview {
           onThumbnails().onFirst().performClick()
+        }
+      }
+    }
+  }
+
+  @Test
+  fun showsImageWhoseThumbnailWasClickedWhenNavigatingToGallery() {
+    with(composeRule) {
+      onTimeline().performScrollToPostPreviewWithGalleryPreview { post ->
+        perform({ onThumbnails() }) { index ->
+          performClick()
+          onPager().performScrollToEachPage {
+            assertContentDescriptionIsCohesiveToPagePosition(post, entrypointIndex = index)
+          }
+          onCloseActionButton().performClick()
         }
       }
     }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/SemanticsMatcherExtensionsTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/SemanticsMatcherExtensionsTests.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.app.demo
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.orca.app.demo.test.isPostPreview
+import com.jeanbarrossilva.orca.autos.colors.Colors
+import com.jeanbarrossilva.orca.composite.timeline.post.LoadedPostPreview
+import com.jeanbarrossilva.orca.composite.timeline.post.PostPreview
+import com.jeanbarrossilva.orca.composite.timeline.test.post.onPostPreview
+import com.jeanbarrossilva.orca.composite.timeline.test.post.time.StringRelativeTimeProvider
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import org.junit.Rule
+import org.junit.Test
+
+internal class SemanticsMatcherExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun linksPostPreview() {
+    lateinit var colors: Colors
+    composeRule.setContent {
+      AutosTheme {
+        AutosTheme.colors.let {
+          DisposableEffect(Unit) {
+            colors = it
+            onDispose {}
+          }
+        }
+
+        LoadedPostPreview(relativeTimeProvider = StringRelativeTimeProvider)
+      }
+    }
+    composeRule.onPostPreview().assert(isPostPreview(PostPreview.getSample(colors)))
+  }
+}

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/SemanticsNodeInteractionCollectionExtensionsTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/SemanticsNodeInteractionCollectionExtensionsTests.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.app.demo
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasTextExactly
+import androidx.compose.ui.test.junit4.createComposeRule
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import com.jeanbarrossilva.orca.app.demo.test.perform
+import org.junit.Rule
+import org.junit.Test
+
+internal class SemanticsNodeInteractionCollectionExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun performsActionOnEachNode() {
+    val texts = arrayOfNulls<String>(size = 2)
+    composeRule
+      .apply {
+        setContent {
+          Text("0")
+          Text("1")
+        }
+      }
+      .perform({ onAllNodes(hasTextExactly("0") or hasTextExactly("1")) }) {
+        texts[it] = fetchSemanticsNode().config[SemanticsProperties.Text].single().toString()
+      }
+    assertThat(texts).containsExactly("0", "1")
+  }
+
+  @Test(expected = AssertionError::class)
+  fun throwsAssertionErrorThrownByActionPerformedOnEachNode() {
+    composeRule
+      .apply {
+        setContent {
+          Text("2")
+          Text("3")
+        }
+      }
+      .perform({ onAllNodes(hasTextExactly("2") or hasTextExactly("3")) }) {
+        assertIsNotDisplayed()
+      }
+  }
+}

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/SemanticsNodeInteractionExtensionsTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/SemanticsNodeInteractionExtensionsTests.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.app.demo
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.orca.app.demo.test.isPostPreview
+import com.jeanbarrossilva.orca.app.demo.test.performScrollToPostIndex
+import com.jeanbarrossilva.orca.autos.colors.Colors
+import com.jeanbarrossilva.orca.composite.timeline.Timeline
+import com.jeanbarrossilva.orca.composite.timeline.post.PostPreview
+import com.jeanbarrossilva.orca.composite.timeline.test.onTimeline
+import com.jeanbarrossilva.orca.composite.timeline.test.post.onPostPreviews
+import com.jeanbarrossilva.orca.core.sample.feed.profile.post.Posts
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import com.jeanbarrossilva.orca.platform.core.withSamples
+import org.junit.Rule
+import org.junit.Test
+
+internal class SemanticsNodeInteractionExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun performsScrollToPostIndex() {
+    lateinit var colors: Colors
+    composeRule
+      .apply {
+        setContent {
+          AutosTheme {
+            AutosTheme.colors.let {
+              DisposableEffect(Unit) {
+                colors = it
+                onDispose {}
+              }
+            }
+
+            Timeline(
+              PostPreview.samples,
+              onFavorite = {},
+              onRepost = {},
+              onShare = {},
+              onClick = {},
+              onNext = {}
+            )
+          }
+        }
+      }
+      .run {
+        onTimeline().performScrollToPostIndex({ it == Posts.withSamples.last() })
+        onPostPreviews().assertAny(isPostPreview(PostPreview.getSamples(colors).last()))
+      }
+  }
+}

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/SemanticsMatcher.extensions.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/SemanticsMatcher.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,20 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.testing
+package com.jeanbarrossilva.orca.app.demo.test
 
-import android.content.res.Resources
-import androidx.annotation.StringRes
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import com.jeanbarrossilva.orca.composite.timeline.post.PostPreview
 
 /**
- * Gets the [String] from this resource ID.
+ * [SemanticsMatcher] that matches a [Composable] that's linked to the given [postPreview].
  *
- * @param format [String] by which arguments in the [String] will be replaced.
+ * @param postPreview [PostPreview] that's expected to be linked.
  */
-fun @receiver:StringRes Int.asString(vararg format: String): String {
-  return try {
-    context.getString(this, *format)
-  } catch (_: Resources.NotFoundException) {
-    InstrumentationRegistry.getInstrumentation().targetContext.getString(this, *format)
+internal fun isPostPreview(postPreview: PostPreview): SemanticsMatcher {
+  return SemanticsMatcher("PostPreview.id = ${postPreview.id}") {
+    it.config[SemanticsProperties.PostPreview].id == postPreview.id
   }
 }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/SemanticsNodeInteraction.extensions.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/SemanticsNodeInteraction.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,22 +17,62 @@ package com.jeanbarrossilva.orca.app.demo.test
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTouchInput
 import com.jeanbarrossilva.orca.composite.timeline.Timeline
 import com.jeanbarrossilva.orca.composite.timeline.post.PostPreview
 import com.jeanbarrossilva.orca.composite.timeline.post.figure.gallery.GalleryPreview
+import com.jeanbarrossilva.orca.composite.timeline.stat.details.formatted
 import com.jeanbarrossilva.orca.composite.timeline.test.isTimeline
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
 import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.sample.auth.actor.sample
-import com.jeanbarrossilva.orca.core.sample.test.instance.sample
-import kotlinx.coroutines.flow.first
+import com.jeanbarrossilva.orca.core.sample.feed.profile.SAMPLE_POSTS_PER_PAGE
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.isPage
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.feature.gallery.ui.page.Index
+import com.jeanbarrossilva.orca.feature.gallery.ui.page.Page
+import com.jeanbarrossilva.orca.platform.core.sample
+import com.jeanbarrossilva.orca.platform.testing.asString
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
+
+/**
+ * Asserts that the content description of the [Page] to which the [SemanticsNode] refers is
+ * cohesive to its position within the [Gallery].
+ *
+ * @param post [Post] from which the [Gallery] was composed.
+ * @param entrypointIndex Index of the thumbnail that was clicked for navigation to the [Gallery] to
+ *   be performed.
+ * @throws AssertionError If the [SemanticsNode] isn't that of a [Page].
+ */
+internal fun SemanticsNodeInteraction.assertContentDescriptionIsCohesiveToPagePosition(
+  post: Post,
+  entrypointIndex: Int
+): SemanticsNodeInteraction {
+  assert(isPage()) {
+    "Cannot assert the cohesiveness of the content description of a node that isn't that of a page."
+  }
+  val position = fetchSemanticsNode().config[SemanticsProperties.Index].inc()
+  val isEntrypoint = entrypointIndex.inc() == position
+  return assertContentDescriptionEquals(
+    if (isEntrypoint) {
+      com.jeanbarrossilva.orca.composite.timeline.R.string
+        .composite_timeline_post_preview_gallery_thumbnail
+        .asString(position.formatted, post.author.name)
+    } else {
+      com.jeanbarrossilva.orca.feature.gallery.R.string.feature_gallery_attachment.asString(
+        position.formatted
+      )
+    }
+  )
+}
 
 /**
  * Scrolls to the index of a [Post] from the sample [Instance] that matches the [predicate].
@@ -47,16 +87,10 @@ internal fun SemanticsNodeInteraction.performScrollToPostIndex(
   predicate: (Post) -> Boolean,
   onPost: (Post) -> Unit = {}
 ): SemanticsNodeInteraction {
-  lateinit var indexedPost: IndexedValue<Post>
-  runTest {
-    indexedPost =
-      Instance.sample.feedProvider
-        .provide(Actor.Authenticated.sample.id, page = 0)
-        .first()
-        .withIndex()
-        .first { predicate(it.value) }
-  }
-  return performScrollToIndex(indexedPost.index).also { onPost(indexedPost.value) }
+  var indexedPost: IndexedValue<Post>? = null
+  runTest { indexedPost = findIndexedPost(predicate = predicate) }
+  return indexedPost?.let { (index, post) -> performScrollToIndex(index).also { onPost(post) } }
+    ?: this
 }
 
 /**
@@ -70,10 +104,35 @@ internal fun SemanticsNodeInteraction.performScrollToPostPreviewWithGalleryPrevi
   onPost: (Post) -> Unit = {}
 ): SemanticsNodeInteraction {
   assert(isTimeline()) { "Can only scroll to the PostPreview with a GalleryPreview of a Timeline." }
-  return performScrollToPostIndex({ it.content.highlight != null }, onPost)
+  return performScrollToPostIndex({ it.content.attachments.isNotEmpty() }, onPost)
 }
 
 /** Performs a click on the portion located at [Offset.Zero] of this [SemanticsNode]. */
 internal fun SemanticsNodeInteraction.performStartClick() {
   performTouchInput { click(Offset.Zero) }
+}
+
+/**
+ * Finds a [Post] within the sample feed that matches the [predicate], returning it alongside its
+ * index.
+ *
+ * @param page Feed page at which the [Post] will be looked for.
+ * @param lastIndex Index of the last [Post] that's been provided while trying to find the matching
+ *   one.
+ * @param predicate Returns whether the given [Post] is the one to be provided.
+ * @see Instance.Companion.sample
+ * @see Instance.feedProvider
+ * @see IndexedValue.index
+ */
+private suspend fun findIndexedPost(
+  page: Int = 0,
+  lastIndex: Int = 0,
+  predicate: (Post) -> Boolean
+): IndexedValue<Post> {
+  return Instance.sample.feedProvider
+    .provide(Actor.Authenticated.sample.id, page)
+    .firstOrNull()
+    ?.mapIndexed { index, post -> IndexedValue(lastIndex + index, post) }
+    ?.find { (_, post) -> predicate(post) }
+    ?: findIndexedPost(page.inc(), lastIndex = SAMPLE_POSTS_PER_PAGE * page.inc(), predicate)
 }

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/Post.extensions.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/Post.extensions.kt
@@ -15,7 +15,6 @@
 
 package com.jeanbarrossilva.orca.composite.timeline.post
 
-import androidx.compose.runtime.Composable
 import com.jeanbarrossilva.orca.autos.colors.Colors
 import com.jeanbarrossilva.orca.composite.timeline.post.figure.Figure
 import com.jeanbarrossilva.orca.composite.timeline.post.figure.gallery.disposition.Disposition
@@ -24,7 +23,6 @@ import com.jeanbarrossilva.orca.composite.timeline.stat.details.asStatsDetails
 import com.jeanbarrossilva.orca.composite.timeline.text.toAnnotatedString
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
 import com.jeanbarrossilva.orca.core.feed.profile.post.repost.Repost
-import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.std.image.compose.SomeComposableImageLoader
 import java.net.URL
 import kotlinx.coroutines.flow.Flow
@@ -57,28 +55,12 @@ fun Post.toPostPreviewFlow(
 /**
  * Converts this [Post] into a [PostPreview].
  *
- * @param onLinkClick Lambda to be run whenever the [Figure.Link]'s content is clicked.
- * @param onThumbnailClickListener [Disposition.OnThumbnailClickListener] that is notified of clicks
- *   on [Thumbnail]s.
- */
-@Composable
-internal fun Post.toPostPreview(
-  onLinkClick: (URL) -> Unit = {},
-  onThumbnailClickListener: Disposition.OnThumbnailClickListener =
-    Disposition.OnThumbnailClickListener.empty
-): PostPreview {
-  return toPostPreview(AutosTheme.colors, onLinkClick, onThumbnailClickListener)
-}
-
-/**
- * Converts this [Post] into a [PostPreview].
- *
  * @param colors [Colors] by which the resulting [PostPreview]'s [PostPreview.text] can be colored.
  * @param onLinkClick Lambda to be run whenever the [Figure.Link]'s content is clicked.
  * @param onThumbnailClickListener [Disposition.OnThumbnailClickListener] that is notified of clicks
  *   on [Thumbnail]s.
  */
-internal fun Post.toPostPreview(
+fun Post.toPostPreview(
   colors: Colors,
   onLinkClick: (URL) -> Unit = {},
   onThumbnailClickListener: Disposition.OnThumbnailClickListener =

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/PostPreview.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/PostPreview.kt
@@ -15,6 +15,7 @@
 
 package com.jeanbarrossilva.orca.composite.timeline.post
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -144,7 +145,7 @@ internal constructor(
 
     /** [PostPreview] samples. */
     val samples
-      @Composable get() = Posts.withSamples.map { it.toPostPreview() }
+      @Composable get() = getSamples(AutosTheme.colors)
 
     /**
      * Gets a sample [PostPreview].
@@ -154,6 +155,16 @@ internal constructor(
      */
     fun getSample(colors: Colors): PostPreview {
       return Posts.withSample.single().toPostPreview(colors)
+    }
+
+    /**
+     * Gets sample [PostPreview]s.
+     *
+     * @param colors [Colors] by which the resulting [PostPreview]s' [text][PostPreview.text]s can
+     *   be colored.
+     */
+    fun getSamples(colors: Colors): List<PostPreview> {
+      return Posts.withSamples.map { it.toPostPreview(colors) }
     }
   }
 }
@@ -181,6 +192,32 @@ fun PostPreview(modifier: Modifier = Modifier) {
     stats = {},
     onClick = null,
     modifier
+  )
+}
+
+/**
+ * Preview of a [Post].
+ *
+ * @param modifier [Modifier] to be applied to the underlying [Card].
+ * @param preview [PostPreview] that holds the overall data to be displayed.
+ * @param relativeTimeProvider [RelativeTimeProvider] that provides the time that's passed since the
+ *   [Post] was published.
+ */
+@Composable
+@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+fun LoadedPostPreview(
+  modifier: Modifier = Modifier,
+  preview: PostPreview = PostPreview.sample,
+  relativeTimeProvider: RelativeTimeProvider = rememberRelativeTimeProvider()
+) {
+  PostPreview(
+    preview,
+    onFavorite = {},
+    onRepost = {},
+    onShare = {},
+    onClick = {},
+    modifier,
+    relativeTimeProvider
   )
 }
 
@@ -241,32 +278,7 @@ fun PostPreview(
       Stats(preview.stats, onComment = {}, onFavorite, onRepost, onShare, Modifier.fillMaxWidth())
     },
     onClick,
-    modifier
-  )
-}
-
-/**
- * Preview of a [Post].
- *
- * @param modifier [Modifier] to be applied to the underlying [Card].
- * @param preview [PostPreview] that holds the overall data to be displayed.
- * @param relativeTimeProvider [RelativeTimeProvider] that provides the time that's passed since the
- *   [Post] was published.
- */
-@Composable
-internal fun LoadedPostPreview(
-  modifier: Modifier = Modifier,
-  preview: PostPreview = PostPreview.sample,
-  relativeTimeProvider: RelativeTimeProvider = rememberRelativeTimeProvider()
-) {
-  PostPreview(
-    preview,
-    onFavorite = {},
-    onRepost = {},
-    onShare = {},
-    onClick = {},
-    modifier,
-    relativeTimeProvider
+    modifier.semantics { postPreview = preview }
   )
 }
 

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/SemanticsProperties.extensions.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/SemanticsProperties.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,14 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.testing
+package com.jeanbarrossilva.orca.composite.timeline.post
 
-import android.content.res.Resources
-import androidx.annotation.StringRes
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 
-/**
- * Gets the [String] from this resource ID.
- *
- * @param format [String] by which arguments in the [String] will be replaced.
- */
-fun @receiver:StringRes Int.asString(vararg format: String): String {
-  return try {
-    context.getString(this, *format)
-  } catch (_: Resources.NotFoundException) {
-    InstrumentationRegistry.getInstrumentation().targetContext.getString(this, *format)
-  }
-}
+/** [SemanticsPropertyKey] returned by [PostPreview]. */
+private val postPreviewSemanticsPropertyKey = SemanticsPropertyKey<PostPreview>("PostPreview")
+
+/** [SemanticsPropertyKey] of a [PostPreview]. */
+val @receiver:Suppress("UnusedReceiverParameter") SemanticsProperties.PostPreview
+  get() = postPreviewSemanticsPropertyKey

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/SemanticsPropertyReceiver.extensions.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/SemanticsPropertyReceiver.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,11 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.testing
+package com.jeanbarrossilva.orca.composite.timeline.post
 
-import android.content.res.Resources
-import androidx.annotation.StringRes
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 
-/**
- * Gets the [String] from this resource ID.
- *
- * @param format [String] by which arguments in the [String] will be replaced.
- */
-fun @receiver:StringRes Int.asString(vararg format: String): String {
-  return try {
-    context.getString(this, *format)
-  } catch (_: Resources.NotFoundException) {
-    InstrumentationRegistry.getInstrumentation().targetContext.getString(this, *format)
-  }
-}
+/** [PostPreview] to which a [Composable] is linked. */
+internal var SemanticsPropertyReceiver.postPreview by SemanticsProperties.PostPreview

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/figure/gallery/disposition/Disposition.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/figure/gallery/disposition/Disposition.kt
@@ -205,8 +205,8 @@ sealed class Disposition {
           onClick = {
             onThumbnailClickListener.onThumbnailClickListener(
               postID,
-              entrypointIndex = 1,
-              preview.attachments.minusAt(1),
+              entrypointIndex = 0,
+              preview.attachments.minusAt(0),
               entrypoint = it
             )
           },
@@ -223,8 +223,8 @@ sealed class Disposition {
               onClick = { copy ->
                 onThumbnailClickListener.onThumbnailClickListener(
                   postID,
-                  entrypointIndex = 2,
-                  preview.attachments.minusAt(2),
+                  entrypointIndex = 1,
+                  preview.attachments.minusAt(1),
                   entrypoint = copy
                 )
               },
@@ -247,8 +247,8 @@ sealed class Disposition {
                 onClick = { copy ->
                   onThumbnailClickListener.onThumbnailClickListener(
                     postID,
-                    entrypointIndex = 3,
-                    attachments.minusAt(3),
+                    entrypointIndex = 2,
+                    attachments.minusAt(2),
                     entrypoint = copy
                   )
                 },

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/SampleFeedProvider.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/SampleFeedProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,7 +18,7 @@ package com.jeanbarrossilva.orca.core.sample.feed
 import com.jeanbarrossilva.orca.core.feed.FeedProvider
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
-import com.jeanbarrossilva.orca.core.sample.feed.profile.SampleProfile
+import com.jeanbarrossilva.orca.core.sample.feed.profile.SAMPLE_POSTS_PER_PAGE
 import com.jeanbarrossilva.orca.core.sample.feed.profile.createSample
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.SamplePostProvider
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.SampleTermMuter
@@ -47,7 +47,7 @@ internal class SampleFeedProvider(
 
   override suspend fun onProvide(userID: String, page: Int): Flow<List<Post>> {
     return postsFlow.map { posts ->
-      posts.chunked(SampleProfile.POSTS_PER_PAGE).getOrElse(page) { posts.takeLast(1) }
+      posts.chunked(SAMPLE_POSTS_PER_PAGE).getOrElse(page) { posts.takeLast(1) }
     }
   }
 

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfile.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -22,6 +22,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 
+/** Maximum amount of [Post]s emitted by [SampleProfile.getPosts]. */
+const val SAMPLE_POSTS_PER_PAGE = 50
+
 /** [Profile] whose operations are performed in memory and serves as a sample. */
 internal interface SampleProfile : Profile {
   /** [SamplePostProvider] by which this [SampleProfile]'s [Post]s will be provided. */
@@ -29,12 +32,7 @@ internal interface SampleProfile : Profile {
 
   override suspend fun getPosts(page: Int): Flow<List<Post>> {
     return postProvider.provideBy(id).filterNotNull().map {
-      it.windowed(POSTS_PER_PAGE, partialWindows = true).getOrElse(page) { emptyList() }
+      it.windowed(SAMPLE_POSTS_PER_PAGE, partialWindows = true).getOrElse(page) { emptyList() }
     }
-  }
-
-  companion object {
-    /** Maximum amount of [Post]s emitted to [getPosts]. */
-    const val POSTS_PER_PAGE = 50
   }
 }

--- a/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/ProfileExtensionsTests.kt
+++ b/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/ProfileExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -31,7 +31,7 @@ internal class ProfileExtensionsTests {
   fun `GIVEN a sample profile WHEN getting its posts THEN they are the sample ones`() {
     runTest {
       assertContentEquals(
-        Posts.withSamples.filter { it.author == Author.sample }.take(SampleProfile.POSTS_PER_PAGE),
+        Posts.withSamples.filter { it.author == Author.sample }.take(SAMPLE_POSTS_PER_PAGE),
         Profile.sample.getPosts(0).first()
       )
     }

--- a/feature/gallery-test/build.gradle.kts
+++ b/feature/gallery-test/build.gradle.kts
@@ -28,8 +28,17 @@ android {
 }
 
 dependencies {
+  androidTestImplementation(libs.assertk)
+
+  implementation(project(":composite:timeline"))
   implementation(project(":feature:gallery"))
   implementation(project(":platform:autos"))
+  implementation(project(":platform:testing"))
+  implementation(project(":platform:ui-test"))
   implementation(libs.android.compose.ui.test.junit)
   implementation(libs.android.compose.ui.test.manifest)
+  implementation(libs.android.test.espresso.core)
+  implementation(libs.loadable.placeholder.test)
 }
+
+kotlin.compilerOptions.freeCompilerArgs.add("-Xcontext-receivers")

--- a/feature/gallery-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/ComposeTestRuleExtensionsTests.kt
+++ b/feature/gallery-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/ComposeTestRuleExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,14 +13,13 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.gallery.ui
+package com.jeanbarrossilva.orca.feature.gallery.test.ui
 
-import android.view.ViewConfiguration
-import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
-import assertk.assertThat
-import assertk.assertions.isGreaterThanOrEqualTo
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.waitForDoubleTapTimeout
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.onPage
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
 import org.junit.Test
 
@@ -28,10 +27,7 @@ internal class ComposeTestRuleExtensionsTests {
   @get:Rule val composeRule = createComposeRule()
 
   @Test
-  fun waitsForDoubleTapTimeout() {
-    assertThat(
-        composeRule.apply(ComposeContentTestRule::waitForDoubleTapTimeout).mainClock.currentTime
-      )
-      .isGreaterThanOrEqualTo(ViewConfiguration.getDoubleTapTimeout().toLong())
+  fun findsCurrentPage() {
+    composeRule.apply { setContent { AutosTheme { Gallery() } } }.onPage().assertIsDisplayed()
   }
 }

--- a/feature/gallery-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsMatcherExtensionsTests.kt
+++ b/feature/gallery-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsMatcherExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,7 +13,7 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.gallery.ui
+package com.jeanbarrossilva.orca.feature.gallery.test.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.ui.res.painterResource
@@ -22,12 +22,9 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.isDisplayed
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.isImage
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.isPage
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.isPager
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPage
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPager
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.isPage
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.onPage
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
 import org.junit.Test

--- a/feature/gallery-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsNodeInteractionExtensionsTests.kt
+++ b/feature/gallery-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsNodeInteractionExtensionsTests.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.feature.gallery.test.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jeanbarrossilva.orca.composite.timeline.stat.details.formatted
+import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
+import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.samples
+import com.jeanbarrossilva.orca.feature.gallery.R
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.onPage
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import com.jeanbarrossilva.orca.platform.testing.asString
+import org.junit.Rule
+import org.junit.Test
+
+internal class SemanticsNodeInteractionExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test(expected = AssertionError::class)
+  fun throwsWhenScrollingToPageOfNonGalleryPagerNode() {
+    composeRule
+      .apply {
+        setContent {
+          @OptIn(ExperimentalFoundationApi::class)
+          HorizontalPager(rememberPagerState { 2 }) { Text("$it") }
+        }
+      }
+      .run { onRoot().performScrollToPageAfter(0) }
+  }
+
+  @Test
+  fun scrollsToPageOfGalleryPager() {
+    composeRule
+      .apply { setContent { AutosTheme { Gallery() } } }
+      .run {
+        onPager().performScrollToPageAfter(0)
+        onPage()
+      }
+      .assertContentDescriptionEquals(R.string.feature_gallery_attachment.asString(2.formatted))
+  }
+
+  @Test
+  fun scrollsToEachPageOfGalleryPager() {
+    var positions = IntRange.EMPTY
+    composeRule
+      .apply { setContent { AutosTheme { Gallery() } } }
+      .run {
+        onPager().performScrollToEachPage {
+          positions = 1..it
+          assertContentDescriptionEquals(R.string.feature_gallery_attachment.asString(it.formatted))
+        }
+      }
+    assertThat(positions).isEqualTo(1..Attachment.samples.size.inc())
+  }
+
+  @Test
+  fun scrollsToRemainingPagesOfGalleryPager() {
+    var positions = IntRange.EMPTY
+    composeRule
+      .apply { setContent { AutosTheme { Gallery() } } }
+      .run {
+        onPager().performScrollToPageAfter(0).performScrollToEachPage {
+          positions = if (it == 2) 2..2 else positions.first..it
+          assertContentDescriptionEquals(R.string.feature_gallery_attachment.asString(it.formatted))
+        }
+      }
+    assertThat(positions).isEqualTo(2..Attachment.samples.size.inc())
+  }
+}

--- a/feature/gallery-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/feature/gallery-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -18,6 +18,7 @@ package com.jeanbarrossilva.orca.feature.gallery.test.ui
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.jeanbarrossilva.orca.feature.gallery.ui.Actions
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
 import org.junit.Test
@@ -31,5 +32,10 @@ internal class SemanticsNodeInteractionsProviderExtensionsTests {
       .apply { setContent { AutosTheme { Actions() } } }
       .onCloseActionButton()
       .assertIsDisplayed()
+  }
+
+  @Test
+  fun findsPager() {
+    composeRule.apply { setContent { AutosTheme { Gallery() } } }.onPager().assertIsDisplayed()
   }
 }

--- a/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsMatcher.extensions.kt
+++ b/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsMatcher.extensions.kt
@@ -13,7 +13,7 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.gallery.ui.test
+package com.jeanbarrossilva.orca.feature.gallery.test.ui
 
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.ui.geometry.Offset
@@ -26,7 +26,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers
@@ -38,11 +37,12 @@ import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
  *
  * **NOTE**: Most of the implementation is as [SemanticsNodeInteraction.isDisplayed]'s is, since no
  * version of it has been made publicly available specifically for strictly-assertion-driven
- * scenarios (such an `isDisplayed()` [SemanticsMatcher] like this one) as of version 1.5.3 of
+ * scenarios (such as an `isDisplayed()` [SemanticsMatcher] like this one) as of version 1.5.3 of
  * Jetpack Compose. If it is to be officially provided in an adopted future version, it is highly
  * recommended to migrate to it instead of relying on this one.
  */
-internal fun isDisplayed(): SemanticsMatcher {
+@Suppress("VisibleForTests")
+fun isDisplayed(): SemanticsMatcher {
   return SemanticsMatcher("is displayed") { node ->
     fun isNotPlaced(layoutInfo: LayoutInfo): Boolean {
       return !layoutInfo.isPlaced
@@ -119,6 +119,11 @@ internal fun isDisplayed(): SemanticsMatcher {
   }
 }
 
+/** [SemanticsMatcher] that matches a [Gallery]'s [HorizontalPager]. */
+fun isPager(): SemanticsMatcher {
+  return hasTestTag(GALLERY_PAGER_TAG)
+}
+
 /**
  * [SemanticsMatcher] that matches an image.
  *
@@ -128,14 +133,4 @@ internal fun isImage(): SemanticsMatcher {
   return SemanticsMatcher("is image") {
     it.config.getOrNull(SemanticsProperties.Role) == Role.Image
   }
-}
-
-/** [SemanticsMatcher] that matches a [Gallery]'s [HorizontalPager]. */
-internal fun isPager(): SemanticsMatcher {
-  return hasTestTag(GALLERY_PAGER_TAG)
-}
-
-/** [SemanticsMatcher] that matches a [Gallery]'s [HorizontalPager]'s current page. */
-internal fun isPage(): SemanticsMatcher {
-  return hasParent(isPager()) and isDisplayed() and isImage()
 }

--- a/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsNodeInteraction.extensions.kt
+++ b/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsNodeInteraction.extensions.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.feature.gallery.test.ui
+
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.performScrollToIndex
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.isPage
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.onPage
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.feature.gallery.ui.page.Index
+
+/**
+ * Scrolls to each page of the [Gallery]'s [HorizontalPager] and runs the given [onSettling]
+ * callback on them.
+ *
+ * @param onSettling Action to be run on the first page and the subsequent ones when they are
+ *   scrolled to. Note that the [Int] it receives is the position of the page (which is index + 1)
+ *   rather than its index; the position of the first one is 1, second's is 2, third's is 3, and so
+ *   on.
+ * @throws AssertionError If this [SemanticsNodeInteraction]'s [SemanticsNode] isn't that of a
+ *   [Gallery]'s [HorizontalPager].
+ */
+context(ComposeTestRule)
+
+@Throws(AssertionError::class)
+fun SemanticsNodeInteraction.performScrollToEachPage(
+  onSettling: SemanticsNodeInteraction.(position: Int) -> Unit = {}
+): SemanticsNodeInteraction {
+  var page = onPage()
+  val getPageIndex = { page.fetchSemanticsNode().config[SemanticsProperties.Index] }
+  var index = getPageIndex()
+  while (true) {
+    page.onSettling(index.inc())
+    try {
+      performScrollToPageAfter(index)
+      page = onPage()
+      index = getPageIndex()
+    } catch (_: IndexOutOfBoundsException) {
+      break
+    }
+  }
+  return this
+}
+
+/**
+ * Scrolls to the page of the [Gallery]'s [HorizontalPager] at the position of the given [index].
+ *
+ * @param index Index of the page to scroll to. Note that the page's position, which is [index] + 1,
+ *   is what will be taken into account when performing the scroll.
+ * @throws AssertionError If this [SemanticsNodeInteraction]'s [SemanticsNode] isn't that of a
+ *   [Gallery]'s [HorizontalPager].
+ * @throws IndexOutOfBoundsException If there is no page at the position of the [index].
+ */
+context(ComposeTestRule)
+
+@Throws(AssertionError::class)
+internal fun SemanticsNodeInteraction.performScrollToPageAfter(
+  index: Int
+): SemanticsNodeInteraction {
+  assert(isPager()) { "Can only scroll to a page of a Gallery's HorizontalPager." }
+  val position = index.inc()
+  return try {
+    performScrollToIndex(position).also {
+      @OptIn(ExperimentalTestApi::class) waitUntilExactlyOneExists(isPage())
+    }
+  } catch (e: IllegalArgumentException) {
+    throw IndexOutOfBoundsException("Index out of range: $index.")
+  }
+}

--- a/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsNodeInteractionsProvider.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,14 +15,25 @@
 
 package com.jeanbarrossilva.orca.feature.gallery.test.ui
 
+import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.onNodeWithTag
 import com.jeanbarrossilva.orca.feature.gallery.ui.Actions
 import com.jeanbarrossilva.orca.feature.gallery.ui.GALLERY_ACTIONS_CLOSE_BUTTON_TAG
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.icon.HoverableIconButton
 
-/** [SemanticsNodeInteraction] of a gallery's [Actions]' close [HoverableIconButton]. */
+/** [SemanticsNodeInteraction] of a [Gallery]'s [Actions]' close [HoverableIconButton]. */
 fun SemanticsNodeInteractionsProvider.onCloseActionButton(): SemanticsNodeInteraction {
   return onNodeWithTag(GALLERY_ACTIONS_CLOSE_BUTTON_TAG)
+}
+
+/**
+ * [SemanticsNodeInteraction] of a [Gallery]'s [HorizontalPager].
+ *
+ * @see isPager
+ */
+fun SemanticsNodeInteractionsProvider.onPager(): SemanticsNodeInteraction {
+  return onNode(isPager())
 }

--- a/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/page/ComposeTestRule.extensions.kt
+++ b/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/page/ComposeTestRule.extensions.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.feature.gallery.test.ui.page
+
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onChildren
+import com.jeanbarrossilva.loadable.placeholder.test.isNotLoading
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.onPager
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.platform.ui.test.DefaultTimeout
+
+/**
+ * [SemanticsNodeInteraction] of a [Gallery]'s [HorizontalPager]'s current page.
+ *
+ * @see onPager
+ */
+fun ComposeTestRule.onPage(): SemanticsNodeInteraction {
+  val nonLoadingPage = isPage() and isNotLoading()
+
+  @OptIn(ExperimentalTestApi::class)
+  waitUntilExactlyOneExists(nonLoadingPage, DefaultTimeout.inWholeMilliseconds)
+
+  return onPager().onChildren().filterToOne(nonLoadingPage)
+}

--- a/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/page/SemanticsMatcher.extensions.kt
+++ b/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/page/SemanticsMatcher.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,21 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.gallery.ui.test
+package com.jeanbarrossilva.orca.feature.gallery.test.ui.page
 
-import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasParent
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.isDisplayed
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.isImage
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.isPager
+import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
 
 /**
- * Returns whether the [matcher] matches the [SemanticsNode] fetched from this
- * [SemanticsNodeInteraction].
+ * [SemanticsMatcher] that matches a [Gallery]'s [HorizontalPager]'s current page.
  *
- * @param matcher [SemanticsMatcher] to match the [SemanticsNode] against.
- * @see SemanticsMatcher.matches
- * @see SemanticsNodeInteraction.fetchSemanticsNode
+ * @see isPager
  */
-internal operator fun SemanticsNodeInteraction.get(matcher: SemanticsMatcher): Boolean {
-  val node = fetchSemanticsNode()
-  return matcher.matches(node)
+fun isPage(): SemanticsMatcher {
+  return hasParent(isPager()) and isDisplayed() and isImage()
 }

--- a/feature/gallery/build.gradle.kts
+++ b/feature/gallery/build.gradle.kts
@@ -23,7 +23,6 @@ android {
   buildFeatures.compose = true
   composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
   defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-  kotlin.compilerOptions.freeCompilerArgs.add("-Xcontext-receivers")
 }
 
 dependencies {
@@ -37,9 +36,7 @@ dependencies {
   androidTestImplementation(libs.android.compose.ui.test.manifest)
   androidTestImplementation(libs.android.fragment.testing)
   androidTestImplementation(libs.android.test.core)
-  androidTestImplementation(libs.android.test.espresso.core)
   androidTestImplementation(libs.assertk)
-  androidTestImplementation(libs.loadable.placeholder.test)
 
   api(project(":composite:composable"))
 
@@ -53,3 +50,5 @@ dependencies {
   implementation(project(":platform:ui"))
   implementation(libs.zoomable)
 }
+
+kotlin.compilerOptions.freeCompilerArgs.add("-Xcontext-receivers")

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivityTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivityTests.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.unit.Dp
 import com.jeanbarrossilva.orca.composite.timeline.stat.details.formatted
 import com.jeanbarrossilva.orca.feature.gallery.test.activity.TestGalleryModule
 import com.jeanbarrossilva.orca.feature.gallery.test.launchGalleryActivity
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPager
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.performScrollToEachPage
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.onPager
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.performScrollToEachPage
 import com.jeanbarrossilva.orca.platform.testing.asString
 import com.jeanbarrossilva.orca.platform.testing.context
 import com.jeanbarrossilva.orca.platform.testing.screen.screen

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ActivityScenario.extensions.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ActivityScenario.extensions.kt
@@ -29,7 +29,7 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.post.Posts
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.samples
 import com.jeanbarrossilva.orca.core.sample.image.CoverImageSource
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
-import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.feature.gallery.ui.SampleGallery
 import com.jeanbarrossilva.orca.platform.core.image.createSample
 import com.jeanbarrossilva.orca.platform.core.withSample
 import com.jeanbarrossilva.orca.platform.testing.context
@@ -41,7 +41,7 @@ import com.jeanbarrossilva.orca.std.image.compose.ComposableImageLoader
  * @param postID ID of the [Post] to which the [Attachment]s belong.
  * @param entrypointIndex Index at which the [entrypoint] is.
  * @param secondary [Attachment]s to be shown in the pages other than the [entrypoint].
- * @param entrypoint Entrypoint page of the [Gallery].
+ * @param entrypoint Entrypoint page of the [SampleGallery].
  */
 internal fun launchGalleryActivity(
   postID: String = Posts.withSample.single().id,

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/GalleryTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/GalleryTests.kt
@@ -28,13 +28,13 @@ import com.jeanbarrossilva.orca.composite.timeline.test.stat.activateable.favori
 import com.jeanbarrossilva.orca.composite.timeline.test.stat.activateable.repost.onRepostStat
 import com.jeanbarrossilva.orca.composite.timeline.test.stat.onCommentStat
 import com.jeanbarrossilva.orca.feature.gallery.test.ui.onCloseActionButton
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.onPager
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.onPage
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.performScrollToEachPage
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.onActions
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.onDownloadItem
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.onOptionsButton
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.onOptionsMenu
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPage
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPager
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.performScrollToEachPage
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.waitForDoubleTapTimeout
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.zoom.assertIsZoomedIn
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.zoom.assertIsZoomedOut
@@ -51,7 +51,7 @@ internal class GalleryTests {
   fun closes() {
     var isClosed = false
     composeRule
-      .apply { setContent { AutosTheme { Gallery(onClose = { isClosed = true }) } } }
+      .apply { setContent { AutosTheme { SampleGallery(onClose = { isClosed = true }) } } }
       .onCloseActionButton()
       .performClick()
     assertThat(isClosed).isTrue()
@@ -61,7 +61,7 @@ internal class GalleryTests {
   fun downloads() {
     var isDownloaded = false
     composeRule
-      .apply { setContent { AutosTheme { Gallery(onDownload = { isDownloaded = true }) } } }
+      .apply { setContent { AutosTheme { SampleGallery(onDownload = { isDownloaded = true }) } } }
       .run {
         onOptionsButton().performClick()
         onDownloadItem().performClick()
@@ -85,7 +85,7 @@ internal class GalleryTests {
   fun comments() {
     var hasCommented = false
     composeRule
-      .apply { setContent { AutosTheme { Gallery(onComment = { hasCommented = true }) } } }
+      .apply { setContent { AutosTheme { SampleGallery(onComment = { hasCommented = true }) } } }
       .onCommentStat()
       .performClick()
     assertThat(hasCommented).isTrue()
@@ -95,7 +95,7 @@ internal class GalleryTests {
   fun favorites() {
     var isFavorited = false
     composeRule
-      .apply { setContent { AutosTheme { Gallery(onFavorite = { isFavorited = true }) } } }
+      .apply { setContent { AutosTheme { SampleGallery(onFavorite = { isFavorited = true }) } } }
       .onFavoriteStat()
       .performClick()
     assertThat(isFavorited).isTrue()
@@ -105,7 +105,7 @@ internal class GalleryTests {
   fun reposts() {
     var isReposted = false
     composeRule
-      .apply { setContent { AutosTheme { Gallery(onRepost = { isReposted = true }) } } }
+      .apply { setContent { AutosTheme { SampleGallery(onRepost = { isReposted = true }) } } }
       .onRepostStat()
       .performClick()
     assertThat(isReposted).isTrue()

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/SemanticsNodeInteractionExtensionsTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/SemanticsNodeInteractionExtensionsTests.kt
@@ -15,31 +15,16 @@
 
 package com.jeanbarrossilva.orca.feature.gallery.ui
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Text
-import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.hasTextExactly
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import assertk.assertThat
-import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
-import com.jeanbarrossilva.orca.composite.timeline.stat.details.formatted
-import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
-import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.samples
-import com.jeanbarrossilva.orca.feature.gallery.R
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.get
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPage
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPager
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.performScrollToEachPage
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.performScrollToPageAt
-import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
-import com.jeanbarrossilva.orca.platform.testing.asString
 import org.junit.Rule
 import org.junit.Test
 
@@ -57,42 +42,5 @@ internal class SemanticsNodeInteractionExtensionsTests {
         composeRule.apply { setContent { Text("🐋") } }.onNodeWithText("🐋")[hasTextExactly("🦈")]
       )
       .isFalse()
-  }
-
-  @Test(expected = AssertionError::class)
-  fun throwsWhenScrollingToPageOfNonGalleryPagerNode() {
-    composeRule
-      .apply {
-        setContent {
-          @OptIn(ExperimentalFoundationApi::class)
-          HorizontalPager(rememberPagerState { 2 }) { Text("$it") }
-        }
-      }
-      .run { onRoot().performScrollToPageAt(0) }
-  }
-
-  @Test
-  fun scrollsToPageOfGalleryPager() {
-    composeRule
-      .apply { setContent { AutosTheme { Gallery() } } }
-      .run {
-        onPager().performScrollToPageAt(0)
-        onPage()
-      }
-      .assertContentDescriptionEquals(R.string.feature_gallery_attachment.asString(2.formatted))
-  }
-
-  @Test
-  fun scrollsToEachPageOfGalleryPager() {
-    var positions = IntRange.EMPTY
-    composeRule
-      .apply { setContent { AutosTheme { Gallery() } } }
-      .run {
-        onPager().performScrollToEachPage {
-          positions = 1..it
-          assertContentDescriptionEquals(R.string.feature_gallery_attachment.asString(it.formatted))
-        }
-      }
-    assertThat(positions).isEqualTo(1..Attachment.samples.size.inc())
   }
 }

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -22,7 +22,6 @@ import com.jeanbarrossilva.orca.feature.gallery.ui.test.onActions
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.onDownloadItem
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.onOptionsButton
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.onOptionsMenu
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPager
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
 import org.junit.Test
@@ -58,10 +57,5 @@ internal class SemanticsNodeInteractionsProviderExtensionsTests {
       .apply { setContent { AutosTheme { Actions(areOptionsVisible = true) } } }
       .onDownloadItem()
       .assertIsDisplayed()
-  }
-
-  @Test
-  fun findsPager() {
-    composeRule.apply { setContent { AutosTheme { Gallery() } } }.onPager().assertIsDisplayed()
   }
 }

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/test/ComposeTestRule.extensions.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/test/ComposeTestRule.extensions.kt
@@ -16,29 +16,7 @@
 package com.jeanbarrossilva.orca.feature.gallery.ui.test
 
 import android.view.ViewConfiguration
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onChildren
-import com.jeanbarrossilva.loadable.placeholder.test.isNotLoading
-import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
-import com.jeanbarrossilva.orca.platform.ui.test.DefaultTimeout
-
-/**
- * [SemanticsNodeInteraction] of a [Gallery]'s [HorizontalPager]'s current page.
- *
- * @see onPager
- */
-internal fun ComposeTestRule.onPage(): SemanticsNodeInteraction {
-  val nonLoadingPage = isPage() and isNotLoading()
-
-  @OptIn(ExperimentalTestApi::class)
-  waitUntilExactlyOneExists(nonLoadingPage, DefaultTimeout.inWholeMilliseconds)
-
-  return onPager().onChildren().filterToOne(nonLoadingPage)
-}
 
 /**
  * Waits until the double tap timeout duration (as it is defined by [ViewConfiguration]) has been

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/test/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/test/SemanticsNodeInteractionsProvider.extensions.kt
@@ -15,7 +15,6 @@
 
 package com.jeanbarrossilva.orca.feature.gallery.ui.test
 
-import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
@@ -25,17 +24,17 @@ import com.jeanbarrossilva.orca.feature.gallery.ui.GALLERY_ACTIONS_OPTIONS_BUTTO
 import com.jeanbarrossilva.orca.feature.gallery.ui.GALLERY_ACTIONS_OPTIONS_DOWNLOADS_ITEM_TAG
 import com.jeanbarrossilva.orca.feature.gallery.ui.GALLERY_ACTIONS_OPTIONS_MENU_TAG
 import com.jeanbarrossilva.orca.feature.gallery.ui.GALLERY_ACTIONS_TAG
-import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.feature.gallery.ui.SampleGallery
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.icon.HoverableIconButton
 import com.jeanbarrossilva.orca.platform.autos.kit.menu.DropdownMenu
 
-/** [SemanticsNodeInteraction] of a [Gallery]'s [Actions]. */
+/** [SemanticsNodeInteraction] of a [SampleGallery]'s [Actions]. */
 internal fun SemanticsNodeInteractionsProvider.onActions(): SemanticsNodeInteraction {
   return onNodeWithTag(GALLERY_ACTIONS_TAG)
 }
 
 /**
- * [SemanticsNodeInteraction] of a [Gallery]'s [Actions]' download option [DropdownMenuItem].
+ * [SemanticsNodeInteraction] of a [SampleGallery]'s [Actions]' download option [DropdownMenuItem].
  *
  * @see onActions
  * @see onOptionsButton
@@ -45,7 +44,7 @@ internal fun SemanticsNodeInteractionsProvider.onDownloadItem(): SemanticsNodeIn
 }
 
 /**
- * [SemanticsNodeInteraction] of a [Gallery]'s [Actions]' options [HoverableIconButton].
+ * [SemanticsNodeInteraction] of a [SampleGallery]'s [Actions]' options [HoverableIconButton].
  *
  * @see onActions
  */
@@ -54,19 +53,10 @@ internal fun SemanticsNodeInteractionsProvider.onOptionsButton(): SemanticsNodeI
 }
 
 /**
- * [SemanticsNodeInteraction] of a [Gallery]'s [Actions]' options [DropdownMenu].
+ * [SemanticsNodeInteraction] of a [SampleGallery]'s [Actions]' options [DropdownMenu].
  *
  * @see onActions
  */
 internal fun SemanticsNodeInteractionsProvider.onOptionsMenu(): SemanticsNodeInteraction {
   return onNodeWithTag(GALLERY_ACTIONS_OPTIONS_MENU_TAG)
-}
-
-/**
- * [SemanticsNodeInteraction] of a [Gallery]'s [HorizontalPager].
- *
- * @see isPager
- */
-internal fun SemanticsNodeInteractionsProvider.onPager(): SemanticsNodeInteraction {
-  return onNode(isPager())
 }

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/zoom/SemanticsNodeInteractionExtensionsTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/zoom/SemanticsNodeInteractionExtensionsTests.kt
@@ -16,8 +16,8 @@
 package com.jeanbarrossilva.orca.feature.gallery.ui.zoom
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.onPage
 import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPage
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.zoom.assertIsZoomedIn
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.zoom.assertIsZoomedOut
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.zoom.performZoomIn

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/zoom/TouchInjectionScopeExtensionsTests.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/ui/zoom/TouchInjectionScopeExtensionsTests.kt
@@ -18,8 +18,8 @@ package com.jeanbarrossilva.orca.feature.gallery.ui.zoom
 import androidx.compose.ui.test.TouchInjectionScope
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performTouchInput
+import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.onPage
 import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
-import com.jeanbarrossilva.orca.feature.gallery.ui.test.onPage
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.zoom.assertIsZoomedIn
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.zoom.assertIsZoomedOut
 import com.jeanbarrossilva.orca.feature.gallery.ui.test.zoom.performZoomIn

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/Gallery.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/Gallery.kt
@@ -15,6 +15,7 @@
 
 package com.jeanbarrossilva.orca.feature.gallery.ui
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -42,9 +43,17 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.samples
 import com.jeanbarrossilva.orca.feature.gallery.GalleryBoundary
 import com.jeanbarrossilva.orca.feature.gallery.GalleryViewModel
+import com.jeanbarrossilva.orca.feature.gallery.ui.page.Page
+import com.jeanbarrossilva.orca.feature.gallery.ui.page.SampleEntrypoint
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 
-internal const val GALLERY_PAGER_TAG = "gallery-pager-tag"
+const val GALLERY_PAGER_TAG = "gallery-pager-tag"
+
+@Composable
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+fun Gallery(modifier: Modifier = Modifier) {
+  SampleGallery(modifier)
+}
 
 @Composable
 internal fun Gallery(
@@ -74,7 +83,7 @@ internal fun Gallery(
 }
 
 @Composable
-internal fun Gallery(
+internal fun SampleGallery(
   modifier: Modifier = Modifier,
   onDownload: () -> Unit = {},
   onComment: () -> Unit = {},
@@ -116,7 +125,8 @@ private fun Gallery(
 ) {
   var areActionsVisible by rememberSaveable { mutableStateOf(true) }
   var areOptionsVisible by rememberSaveable(areActionsVisible) { mutableStateOf(false) }
-  val pagerState = rememberPagerState(pageCount = secondary.size::inc)
+  val pagerState =
+    rememberPagerState(initialPage = entrypointIndex, pageCount = secondary.size::inc)
   val pages =
     remember(entrypointIndex, secondary) {
       List<@Composable () -> Unit>(pagerState.pageCount) { index ->

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/page/Page.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/page/Page.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,8 +13,9 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.gallery.ui
+package com.jeanbarrossilva.orca.feature.gallery.ui.page
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.animateContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,16 +24,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.content.samples
 import com.jeanbarrossilva.orca.feature.gallery.R
+import com.jeanbarrossilva.orca.feature.gallery.ui.isZoomedInAsState
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.std.image.compose.rememberImageLoader
 import kotlinx.coroutines.launch
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.toggleScale
 import net.engawapg.lib.zoomable.zoomable
+
+@Composable
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+fun Page(modifier: Modifier = Modifier) {
+  Page(
+    entrypointIndex = 0,
+    currentIndex = 1,
+    secondary = Attachment.samples,
+    onActionsVisibilityToggle = {},
+    modifier
+  ) {
+    SampleEntrypoint(it)
+  }
+}
 
 @Composable
 internal fun Page(
@@ -62,6 +79,7 @@ internal fun Page(
         }
       )
       .animateContentSize()
+      .semantics { index = currentIndex }
   if (currentIndex == entrypointIndex) {
     entrypoint(pageModifier)
   } else {
@@ -89,14 +107,5 @@ internal fun SampleEntrypoint(modifier: Modifier = Modifier) {
 @Composable
 @Preview
 private fun PagePreview() {
-  AutosTheme {
-    Page(
-      entrypointIndex = 0,
-      currentIndex = 1,
-      secondary = Attachment.samples,
-      onActionsVisibilityToggle = {}
-    ) {
-      SampleEntrypoint(it)
-    }
-  }
+  AutosTheme { Page() }
 }

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/page/SemanticsProperties.extensions.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/page/SemanticsProperties.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,14 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.testing
+package com.jeanbarrossilva.orca.feature.gallery.ui.page
 
-import android.content.res.Resources
-import androidx.annotation.StringRes
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 
-/**
- * Gets the [String] from this resource ID.
- *
- * @param format [String] by which arguments in the [String] will be replaced.
- */
-fun @receiver:StringRes Int.asString(vararg format: String): String {
-  return try {
-    context.getString(this, *format)
-  } catch (_: Resources.NotFoundException) {
-    InstrumentationRegistry.getInstrumentation().targetContext.getString(this, *format)
-  }
-}
+/** [SemanticsPropertyKey] returned by [Index]. */
+private val indexSemanticsPropertyKey = SemanticsPropertyKey<Int>("Index")
+
+/** [SemanticsPropertyKey] of a [Page]'s index. */
+val @receiver:Suppress("UnusedReceiverParameter") SemanticsProperties.Index
+  get() = indexSemanticsPropertyKey

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/page/SemanticsPropertyReceiver.extensions.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/ui/page/SemanticsPropertyReceiver.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,10 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.testing
+package com.jeanbarrossilva.orca.feature.gallery.ui.page
 
-import android.content.res.Resources
-import androidx.annotation.StringRes
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 
-/**
- * Gets the [String] from this resource ID.
- *
- * @param format [String] by which arguments in the [String] will be replaced.
- */
-fun @receiver:StringRes Int.asString(vararg format: String): String {
-  return try {
-    context.getString(this, *format)
-  } catch (_: Resources.NotFoundException) {
-    InstrumentationRegistry.getInstrumentation().targetContext.getString(this, *format)
-  }
-}
+/** Index of a [Page]. */
+internal var SemanticsPropertyReceiver.index by SemanticsProperties.Index

--- a/platform/core/src/main/java/com/jeanbarrossilva/orca/platform/core/Instance.extensions.kt
+++ b/platform/core/src/main/java/com/jeanbarrossilva/orca/platform/core/Instance.extensions.kt
@@ -16,12 +16,14 @@
 package com.jeanbarrossilva.orca.platform.core
 
 import com.jeanbarrossilva.orca.core.instance.Instance
+import com.jeanbarrossilva.orca.core.sample.feed.profile.post.Posts
 import com.jeanbarrossilva.orca.core.sample.instance.createSample
 import com.jeanbarrossilva.orca.platform.core.image.sample
 import com.jeanbarrossilva.orca.std.image.compose.ComposableImageLoader
 
 /** [Instance] returned by [sample]. */
-private val sampleInstance = Instance.createSample(ComposableImageLoader.Provider.sample)
+private val sampleInstance =
+  Instance.createSample(ComposableImageLoader.Provider.sample, Posts.withSamples)
 
 /** Sample [Instance] whose images are loaded by a sample [ComposableImageLoader]. */
 val Instance.Companion.sample


### PR DESCRIPTION
The entire fix is in the [`Disposition.Grid`](https://github.com/the-orca-app/android/blob/756629f418b689c9d86e00076dd166bdc6963f8c/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/figure/gallery/disposition/Disposition.kt#L124) class, the other changes are merely for testing the fix.

<img src="https://github.com/the-orca-app/android/assets/38408390/db2a4b69-8151-4f8f-9a88-3631680c2ccd" width="256" />
<img src="https://github.com/the-orca-app/android/assets/38408390/643256d0-3443-4828-9cb0-94652e281b85" width="256" />
